### PR TITLE
[ADD] ssi_partner: mekanisme kontak di beberapa perusahaan pada res.partner

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,10 @@ on:
       - "19.0"
       - "19.0-ocabot-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - "19.0"
       - "19.0-ocabot-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unreleased-deps:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     hooks:
       - id: whool-init
   - repo: https://github.com/oca/maintainer-tools
-    rev: f9b919b9868143135a9c9cb03021089cabba8223
+    rev: 31bdbd8e4cb94be6534f0e82b1cafb84a455f671
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -128,7 +128,7 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v9.3.15
+    rev: v10.0.6
     hooks:
       - id: pylint_odoo
         name: pylint with optional checks

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,6 +4,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4
+
 [ODOOLINT]
 readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest-required-authors=PT. Simetri Sinergi Indonesia
@@ -26,6 +29,7 @@ enable=anomalous-backslash-in-string,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
+    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,
@@ -85,6 +89,7 @@ enable=anomalous-backslash-in-string,
     translation-format-interpolation,
     translation-format-truncated,
     translation-fstring-interpolation,
+    translation-injection,
     translation-not-lazy,
     translation-too-few-args,
     translation-too-many-args,

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -3,6 +3,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4
+
 [ODOOLINT]
 readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest-required-authors=PT. Simetri Sinergi Indonesia
@@ -18,6 +21,7 @@ enable=anomalous-backslash-in-string,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
+    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,
@@ -77,6 +81,7 @@ enable=anomalous-backslash-in-string,
     translation-format-interpolation,
     translation-format-truncated,
     translation-fstring-interpolation,
+    translation-injection,
     translation-not-lazy,
     translation-too-few-args,
     translation-too-many-args,

--- a/ssi_partner/README.rst
+++ b/ssi_partner/README.rst
@@ -24,6 +24,14 @@ mutually exclusive notebook pages depending on ``is_company``. Also adds
 the ``partner_contact_group`` master data model, used to group a subset of
 a commercial contact's children for handling as a single unit.
 
+Adds a mechanism for a single person to hold several positions across
+different companies without being duplicated as unrelated contacts: a
+``standalone`` contact can have several ``attached`` positions
+(``contact_id``/``other_contact_ids``) whose name and title are kept in
+sync with it. Contact lists only show standalone contacts by default; the
+"All Positions" filter on the partner search view reveals attached
+contacts as well.
+
 
 Installation
 ============

--- a/ssi_partner/models/__init__.py
+++ b/ssi_partner/models/__init__.py
@@ -11,3 +11,4 @@ from . import res_partner_title  # noqa: F401
 from . import res_partner_bank  # noqa: F401
 from . import res_partner  # noqa: F401
 from . import partner_contact_group  # noqa: F401
+from . import ir_actions_act_window  # noqa: F401

--- a/ssi_partner/models/ir_actions_act_window.py
+++ b/ssi_partner/models/ir_actions_act_window.py
@@ -1,0 +1,28 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class IrActionsActWindow(models.Model):
+    _name = "ir.actions.act_window"
+    _inherit = [
+        "ir.actions.act_window",
+    ]
+
+    def read(self, fields=None, load="_classic_read"):
+        actions = super().read(fields=fields, load=load)
+        for action in actions:
+            if action.get("res_model") == "res.partner":
+                # By default, a contact list only shows standalone contacts.
+                action_context = action.get("context") or "{}"
+                if "search_show_all_positions" not in action_context:
+                    action["context"] = action_context.replace(
+                        "{",
+                        (
+                            "{'search_show_all_positions': "
+                            "{'is_set': True, 'set_value': False},"
+                        ),
+                        1,
+                    )
+        return actions

--- a/ssi_partner/models/partner_contact_group.py
+++ b/ssi_partner/models/partner_contact_group.py
@@ -17,7 +17,6 @@ class PartnerContactGroup(models.Model):
     _description = "Partner Contact Group"
 
     commercial_contact_id = fields.Many2one(
-        string="Commercial Contact",
         comodel_name="res.partner",
         domain=[("parent_id", "=", False)],
         required=True,

--- a/ssi_partner/models/res_partner.py
+++ b/ssi_partner/models/res_partner.py
@@ -273,6 +273,15 @@ class ResPartner(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        for vals in vals_list:
+            # Core enforces `CHECK(type != 'contact' OR name IS NOT NULL)`
+            # at the database level, which runs on the initial INSERT
+            # itself. `_fields_sync()` only fills `name` from `contact_id`
+            # *after* the row already exists, which is too late to satisfy
+            # that constraint, so an attached contact created without an
+            # explicit `name` must have it pre-filled here.
+            if vals.get("contact_id") and not vals.get("name"):
+                vals["name"] = self.browse(vals["contact_id"]).name
         records = super().create(vals_list)
         # `title_id` is a precomputed, user-editable field: when
         # `is_company` and `title_id` are both given explicitly in the

--- a/ssi_partner/models/res_partner.py
+++ b/ssi_partner/models/res_partner.py
@@ -4,6 +4,7 @@
 from datetime import date
 
 from odoo import api, fields, models
+from odoo.fields import Domain
 
 
 class ResPartner(models.Model):
@@ -53,7 +54,6 @@ class ResPartner(models.Model):
         help="Country where the individual contact was born.",
     )
     nationality_id = fields.Many2one(
-        string="Nationality",
         comodel_name="res.country",
         help="Country of nationality/citizenship of the individual contact.",
     )
@@ -75,12 +75,10 @@ class ResPartner(models.Model):
         help="Rhesus factor of the individual contact's blood type.",
     )
     religion_id = fields.Many2one(
-        string="Religion",
         comodel_name="res_partner_religion",
         help="Religion of the individual contact, used for demographic reporting.",
     )
     ethnicity_id = fields.Many2one(
-        string="Ethnicity",
         comodel_name="res_partner_ethnicity",
         help="Ethnicity of the individual contact, used for demographic reporting.",
     )
@@ -107,7 +105,6 @@ class ResPartner(models.Model):
         "contact is married or a legal cohabitant.",
     )
     title_id = fields.Many2one(
-        string="Title",
         comodel_name="res.partner.title",
         ondelete="restrict",
         compute="_compute_title_id",
@@ -121,13 +118,11 @@ class ResPartner(models.Model):
 
     # Company attributes
     ownership_type_id = fields.Many2one(
-        string="Ownership Type",
         comodel_name="company_ownership_type",
         help="How the ownership of the company contact is structured "
         "(e.g. Private, State-Owned, Publicly Listed).",
     )
     entity_type_id = fields.Many2one(
-        string="Entity Type",
         comodel_name="company_entity_type",
         help="Legal entity form of the company contact (e.g. Limited "
         "Liability Company, Partnership, Cooperative).",
@@ -138,6 +133,36 @@ class ResPartner(models.Model):
         relation="rel_res_partner_2_secondary_industry",
         help="Additional industries the company contact operates in, "
         "besides its main industry.",
+    )
+
+    # Contact in several companies
+    contact_type = fields.Selection(
+        selection=[
+            ("standalone", "Standalone Contact"),
+            ("attached", "Attached to existing Contact"),
+        ],
+        compute="_compute_contact_type",
+        store=True,
+        index=True,
+        default="standalone",
+        help="A standalone contact represents a person on its own. An "
+        "attached contact represents one of the several positions held "
+        "by the same person, and keeps its name and title synchronized "
+        "with its main contact.",
+    )
+    contact_id = fields.Many2one(
+        string="Main Contact",
+        comodel_name="res.partner",
+        domain=[("is_company", "=", False), ("contact_type", "=", "standalone")],
+        help="Standalone contact this position belongs to. Name and "
+        "title are kept synchronized with it.",
+    )
+    other_contact_ids = fields.One2many(
+        string="Others Positions",
+        comodel_name="res.partner",
+        inverse_name="contact_id",
+        help="Other positions, in other companies, held by the same "
+        "person as this standalone contact.",
     )
 
     @api.depends("birthdate_date")
@@ -158,6 +183,93 @@ class ResPartner(models.Model):
         for partner in self:
             if partner.is_company:
                 partner.title_id = False
+
+    @api.depends("contact_id")
+    def _compute_contact_type(self):
+        for partner in self:
+            partner.contact_type = "attached" if partner.contact_id else "standalone"
+
+    @api.depends("contact_type", "contact_id")
+    def _compute_commercial_partner(self):
+        result = super()._compute_commercial_partner()
+        for partner in self:
+            if partner.contact_type == "attached" and not partner.parent_id:
+                partner.commercial_partner_id = partner.contact_id
+        return result
+
+    @api.model
+    def _contact_fields(self):
+        """Fields kept synchronized between a standalone contact and the
+        positions attached to it via ``contact_id``."""
+        return ["name", "title_id"]
+
+    def _contact_sync_from_parent(self):
+        """Pull the synchronized fields from the main contact onto self,
+        as if they were related fields."""
+        self.ensure_one()
+        if self.contact_id:
+            contact_fields = self._contact_fields()
+            sync_vals = self.contact_id._convert_fields_to_values(contact_fields)
+            self.write(sync_vals)
+
+    def update_contact(self, vals):
+        """Push a downstream update of the synchronized fields onto self,
+        guarded against recursive sync loops."""
+        if self.env.context.get("__update_contact_lock"):
+            return
+        contact_fields = self._contact_fields()
+        contact_vals = {
+            field_name: vals[field_name]
+            for field_name in contact_fields
+            if field_name in vals
+        }
+        if contact_vals:
+            self.with_context(__update_contact_lock=True).write(contact_vals)
+
+    def _fields_sync(self, values):
+        result = super()._fields_sync(values)
+        contact_fields = self._contact_fields()
+        if values.get("contact_id"):
+            # From UPSTREAM: sync from the newly set main contact.
+            self._contact_sync_from_parent()
+        elif any(field_name in contact_fields for field_name in values):
+            # To DOWNSTREAM: propagate to the main contact and siblings.
+            update_ids = self.other_contact_ids.filtered(lambda p: not p.is_company)
+            if self.contact_id:
+                update_ids |= self.contact_id
+            update_ids.update_contact(values)
+        return result
+
+    def _search(self, domain, offset=0, limit=None, order=None, **kw):
+        show_all_positions = self.env.context.get("search_show_all_positions") or {}
+        if not show_all_positions.get("is_set") or show_all_positions.get("set_value"):
+            return super()._search(
+                domain, offset=offset, limit=limit, order=order, **kw
+            )
+
+        # Display only standalone contacts matching `domain`, or standalone
+        # contacts having an attached contact matching `domain`.
+        no_filter_self = self.with_context(search_show_all_positions={"is_set": False})
+        base_domain = Domain(domain)
+        attached_query = no_filter_self._search(
+            base_domain & Domain("contact_type", "=", "attached")
+        )
+        filtered_domain = (
+            Domain("contact_type", "=", "standalone") & base_domain
+        ) | Domain("other_contact_ids", "in", attached_query)
+        return no_filter_self._search(
+            filtered_domain, offset=offset, limit=limit, order=order, **kw
+        )
+
+    @api.onchange("contact_id")
+    def onchange_name(self):
+        if self.contact_id:
+            self.name = self.contact_id.name
+
+    @api.onchange("contact_type")
+    def onchange_contact_id(self):
+        if self.contact_type == "standalone":
+            self.contact_id = False
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/ssi_partner/models/res_partner_bank.py
+++ b/ssi_partner/models/res_partner_bank.py
@@ -11,7 +11,6 @@ class ResPartnerBank(models.Model):
     ]
 
     usage_id = fields.Many2one(
-        string="Usage",
         comodel_name="res_partner_bank_usage",
         help="Classifies the intended usage of this bank account, e.g. "
         "Operational, Payroll, Tax, or Escrow. Optional.",

--- a/ssi_partner/tests/__init__.py
+++ b/ssi_partner/tests/__init__.py
@@ -10,5 +10,6 @@ from . import test_res_partner_bank_usage
 from . import test_res_partner_title
 from . import test_sql_constraint_res_partner_title
 from . import test_res_partner
+from . import test_res_partner_contact
 from . import test_res_partner_bank
 from . import test_partner_contact_group

--- a/ssi_partner/tests/test_data_res_partner_contact.yaml
+++ b/ssi_partner/tests/test_data_res_partner_contact.yaml
@@ -55,7 +55,8 @@ scenarios:
             expected_records:
               - "REC: person_b"
 
-  - name: "Attached contact without a parent follows the main contact's commercial partner"
+  - name:
+      "Attached contact without a parent follows the main contact's commercial partner"
     steps:
       - step: "Assert commercial_partner_id follows contact_id"
         action: "assert"
@@ -95,7 +96,8 @@ scenarios:
             type: "value"
             expected: "Jane Doe Renamed"
 
-  - name: "Onchange fills the name from the main contact and clears it back to standalone"
+  - name:
+      "Onchange fills the name from the main contact and clears it back to standalone"
     steps:
       - step: "Set contact_id then switch back to standalone"
         action: "form"

--- a/ssi_partner/tests/test_data_res_partner_contact.yaml
+++ b/ssi_partner/tests/test_data_res_partner_contact.yaml
@@ -140,7 +140,7 @@ scenarios:
             set_value: false
         save_as: "found_standalone"
         expect_count: 1
-      - step: "Attached contact is filtered out by the default filter"
+      - step: "Searching by the attached contact's id surfaces its main contact instead"
         action: "search"
         model: "res.partner"
         domain: [["id", "=", "REC: person_b.id"]]
@@ -148,5 +148,12 @@ scenarios:
           search_show_all_positions:
             is_set: true
             set_value: false
-        save_as: "found_attached"
-        expect_count: 0
+        save_as: "found_via_attached_id"
+        expect_count: 1
+      - step: "Assert the surfaced record is the main contact, not the attached one"
+        action: "assert"
+        target: "found_via_attached_id"
+        asserts:
+          id:
+            type: "value"
+            expected: "REC: person_a.id"

--- a/ssi_partner/tests/test_data_res_partner_contact.yaml
+++ b/ssi_partner/tests/test_data_res_partner_contact.yaml
@@ -1,0 +1,150 @@
+setup:
+  steps:
+    - step: "Create standalone main contact"
+      action: "create"
+      model: "res.partner"
+      save_as: "person_a"
+      values:
+        name: "Jane Doe"
+    - step: "Create contact attached to the main contact"
+      action: "create"
+      model: "res.partner"
+      save_as: "person_b"
+      values:
+        contact_id: "REC: person_a.id"
+
+scenarios:
+  - name: "Standalone contact has contact_type standalone"
+    steps:
+      - step: "Assert contact type and empty main contact"
+        action: "assert"
+        target: "person_a"
+        asserts:
+          contact_type:
+            type: "value"
+            expected: "standalone"
+          contact_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Attached contact points to its main contact and inherits its name"
+    steps:
+      - step: "Assert contact type, main contact and inherited name"
+        action: "assert"
+        target: "person_b"
+        asserts:
+          contact_type:
+            type: "value"
+            expected: "attached"
+          contact_id:
+            type: "m2o"
+            expected: "REC: person_a"
+          name:
+            type: "value"
+            expected: "Jane Doe"
+
+  - name: "Main contact lists its attached position"
+    steps:
+      - step: "Assert other_contact_ids contains the attached contact"
+        action: "assert"
+        target: "person_a"
+        asserts:
+          other_contact_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: person_b"
+
+  - name: "Attached contact without a parent follows the main contact's commercial partner"
+    steps:
+      - step: "Assert commercial_partner_id follows contact_id"
+        action: "assert"
+        target: "person_b"
+        asserts:
+          commercial_partner_id:
+            type: "m2o"
+            expected: "REC: person_a"
+
+  - name: "Renaming the main contact propagates to the attached contact"
+    steps:
+      - step: "Rename the main contact"
+        action: "write"
+        target: "person_a"
+        values:
+          name: "Jane Doe Updated"
+      - step: "Assert the attached contact's name follows"
+        action: "assert"
+        target: "person_b"
+        asserts:
+          name:
+            type: "value"
+            expected: "Jane Doe Updated"
+
+  - name: "Renaming the attached contact propagates back to the main contact"
+    steps:
+      - step: "Rename the attached contact"
+        action: "write"
+        target: "person_b"
+        values:
+          name: "Jane Doe Renamed"
+      - step: "Assert the main contact's name follows"
+        action: "assert"
+        target: "person_a"
+        asserts:
+          name:
+            type: "value"
+            expected: "Jane Doe Renamed"
+
+  - name: "Onchange fills the name from the main contact and clears it back to standalone"
+    steps:
+      - step: "Set contact_id then switch back to standalone"
+        action: "form"
+        model: "res.partner"
+        save: false
+        ops:
+          - set:
+              contact_id: "REC: person_a"
+          - assert:
+              name:
+                type: "value"
+                expected: "Jane Doe"
+          - set:
+              contact_type: "standalone"
+          - assert:
+              contact_id:
+                type: "value"
+                operator: "is_falsy"
+
+  - name: "Invalid contact_type value is rejected"
+    steps:
+      - step: "Create with an invalid contact_type must fail"
+        action: "create"
+        model: "res.partner"
+        expect_error:
+          type: "ValueError"
+        values:
+          name: "Invalid Contact Type"
+          contact_type: "external"
+
+  - name: "Default contact list only returns standalone contacts"
+    steps:
+      - step: "Standalone contact is found with the default filter"
+        action: "search"
+        model: "res.partner"
+        domain: [["id", "=", "REC: person_a.id"]]
+        context:
+          search_show_all_positions:
+            is_set: true
+            set_value: false
+        save_as: "found_standalone"
+        expect_count: 1
+      - step: "Attached contact is filtered out by the default filter"
+        action: "search"
+        model: "res.partner"
+        domain: [["id", "=", "REC: person_b.id"]]
+        context:
+          search_show_all_positions:
+            is_set: true
+            set_value: false
+        save_as: "found_attached"
+        expect_count: 0

--- a/ssi_partner/tests/test_res_partner_contact.py
+++ b/ssi_partner/tests/test_res_partner_contact.py
@@ -1,0 +1,12 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestResPartnerContact(YamlTransactionCase):
+    def test_res_partner_contact(self):
+        self.run_yaml_scenario("test_data_res_partner_contact.yaml")

--- a/ssi_partner/views/res_partner.xml
+++ b/ssi_partner/views/res_partner.xml
@@ -55,7 +55,7 @@
                         />
                     </group>
                     <group string="Contact in Several Companies">
-                        <field name="contact_type" />
+                        <field name="contact_type" readonly="0" />
                         <field
                             name="contact_id"
                             required="contact_type == 'attached'"

--- a/ssi_partner/views/res_partner.xml
+++ b/ssi_partner/views/res_partner.xml
@@ -58,7 +58,6 @@
                         <field name="contact_type" />
                         <field
                             name="contact_id"
-                            invisible="contact_type != 'attached'"
                             required="contact_type == 'attached'"
                         />
                     </group>

--- a/ssi_partner/views/res_partner.xml
+++ b/ssi_partner/views/res_partner.xml
@@ -54,6 +54,29 @@
                             invisible="marital not in ['married', 'cohabitant']"
                         />
                     </group>
+                    <group string="Contact in Several Companies">
+                        <field name="contact_type" />
+                        <field
+                            name="contact_id"
+                            invisible="contact_type != 'attached'"
+                            required="contact_type == 'attached'"
+                        />
+                    </group>
+                </page>
+                <page
+                    name="ssi_partner_other_positions"
+                    string="Other Positions"
+                    invisible="is_company or contact_type != 'standalone'"
+                >
+                    <field name="other_contact_ids">
+                        <list>
+                            <field name="name" />
+                            <field name="parent_id" />
+                            <field name="function" />
+                            <field name="email" />
+                            <field name="phone" />
+                        </list>
+                    </field>
                 </page>
                 <page
                     name="ssi_partner_company_information"
@@ -67,6 +90,23 @@
                     </group>
                 </page>
             </notebook>
+        </field>
+    </record>
+
+    <record id="res_partner_view_search" model="ir.ui.view">
+        <field name="name">res.partner - search - all positions filter</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter" />
+        <field name="arch" type="xml">
+            <filter name="type_company" position="after">
+                <separator />
+                <filter
+                    name="type_otherpositions"
+                    string="All Positions"
+                    context="{'search_show_all_positions': {'is_set': True, 'set_value': True}}"
+                    help="Also show contacts attached to another contact as one of their positions"
+                />
+            </filter>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan field `contact_type`, `contact_id`, dan `other_contact_ids` pada
`res.partner` agar satu orang yang menjabat di beberapa perusahaan dapat
direpresentasikan sebagai satu kontak `standalone` beserta beberapa kontak
`attached`, dengan nama dan gelar (`title_id`) tersinkron dua arah lewat
override `_fields_sync` + `_convert_fields_to_values` (API Odoo 19.0,
pengganti `_update_fields_values` yang sudah dihapus dari core res.partner
19.0 — lihat komentar verifikasi di issue).

- `commercial_partner_id` kontak `attached` tanpa `parent_id` mengikuti
  `contact_id`-nya (override `_compute_commercial_partner`).
- Daftar kontak secara default hanya menampilkan kontak `standalone` lewat
  override `_search` (tanda tangan 19.0, tanpa parameter `count`) beserta
  context `search_show_all_positions`; `ir.actions.act_window` di-override
  agar action `res.partner` mendapat default context tersebut bila belum
  ada.
- Filter "All Positions" ditambahkan pada search view; `contact_id` dan
  `other_contact_ids` ditampilkan pada form.
- Turut memperbaiki atribut `string=` yang redundan pada beberapa field
  lama (`res_partner.py`, `res_partner_bank.py`, `partner_contact_group.py`)
  yang baru ketahuan oleh `pylint_odoo` setelah sinkronisasi config
  template OCA (`--all-files`, tidak terkait scope fitur ini).

## Catatan implementasi

Skenario uji "penyaringan daftar kontak" ditulis di YAML (`action: search`
dengan `context:` kustom), bukan Python murni seperti disebutkan di
Skenario Uji issue — pustaka `odoo-yaml-test@19.0` (dipakai CI repo ini)
ternyata mendukung `context:` pada `action: search` (`_build_env` di
`case.py`), sehingga tidak ada keterbatasan `L-xx`/`P9` yang benar-benar
berlaku di sini. Menulisnya di YAML sesuai gerbang wajib skill
`odoo-development-unit-test` ("tanpa kode L-xx yang cocok, test wajib
YAML").

## Test plan

- [x] `pre-commit run --all-files` lolos bersih (lint, format, README, dll).
- [ ] CI GitHub (`test.yml`) menjalankan unit test `odoo-yaml-test` di atas.

Closes #45