### PR TITLE
[ADD] ssi_partner: mesin identifikasi partner (kategori & nomor identitas)

### DIFF
--- a/ssi_partner/README.rst
+++ b/ssi_partner/README.rst
@@ -32,6 +32,14 @@ sync with it. Contact lists only show standalone contacts by default; the
 "All Positions" filter on the partner search view reveals attached
 contacts as well.
 
+Adds a partner identification mechanism: the ``res_partner_id_category``
+master data model (National ID, Tax ID, Driving License, Passport,
+Business Registration Number, etc.), each optionally carrying a Python
+``validation_code`` used to validate the format of numbers assigned to it,
+and the ``res_partner_id_number`` model, shown as an "ID Numbers" tab on
+``res.partner``, tracking the number, issuing partner, issue date, and
+validity period (with a computed Draft/Valid/Expired ``status``).
+
 
 Installation
 ============

--- a/ssi_partner/__manifest__.py
+++ b/ssi_partner/__manifest__.py
@@ -25,6 +25,7 @@
         "security/res_groups/res_partner_bank_usage.xml",
         "security/res_groups/res_partner_title.xml",
         "security/res_groups/partner_contact_group.xml",
+        "security/res_groups/res_partner_id_category.xml",
         "security/ir_model_access/company_ownership_type.xml",
         "security/ir_model_access/company_entity_type.xml",
         "security/ir_model_access/res_partner_religion.xml",
@@ -32,6 +33,8 @@
         "security/ir_model_access/res_partner_bank_usage.xml",
         "security/ir_model_access/res_partner_title.xml",
         "security/ir_model_access/partner_contact_group.xml",
+        "security/ir_model_access/res_partner_id_category.xml",
+        "security/ir_model_access/res_partner_id_number.xml",
         "menu.xml",
         "views/res_partner.xml",
         "views/company_ownership_type.xml",
@@ -42,5 +45,6 @@
         "views/res_partner_title.xml",
         "views/res_partner_bank.xml",
         "views/partner_contact_group.xml",
+        "views/res_partner_id_category.xml",
     ],
 }

--- a/ssi_partner/models/__init__.py
+++ b/ssi_partner/models/__init__.py
@@ -9,6 +9,8 @@ from . import res_partner_ethnicity  # noqa: F401
 from . import res_partner_bank_usage  # noqa: F401
 from . import res_partner_title  # noqa: F401
 from . import res_partner_bank  # noqa: F401
+from . import res_partner_id_category  # noqa: F401
+from . import res_partner_id_number  # noqa: F401
 from . import res_partner  # noqa: F401
 from . import partner_contact_group  # noqa: F401
 from . import ir_actions_act_window  # noqa: F401

--- a/ssi_partner/models/res_partner.py
+++ b/ssi_partner/models/res_partner.py
@@ -165,6 +165,16 @@ class ResPartner(models.Model):
         "person as this standalone contact.",
     )
 
+    # Identification numbers
+    id_numbers = fields.One2many(
+        string="ID Numbers",
+        comodel_name="res_partner_id_number",
+        inverse_name="partner_id",
+        help="Identification numbers held by this contact, e.g. "
+        "National ID, Tax ID, Driving License, Passport, or Business "
+        "Registration Number.",
+    )
+
     @api.depends("birthdate_date")
     def _compute_age(self):
         today = date.today()

--- a/ssi_partner/models/res_partner_id_category.py
+++ b/ssi_partner/models/res_partner_id_category.py
@@ -1,0 +1,33 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResPartnerIdCategory(models.Model):
+    """Represents a category of partner identification numbers (e.g.
+    National ID, Tax ID, Driving License, Passport, Business
+    Registration Number). Each category may carry its own Python
+    validation code, used to check the format of the identification
+    numbers assigned to it."""
+
+    _name = "res_partner_id_category"
+    _inherit = [
+        "mixin.master_data",
+    ]
+    _description = "Partner ID Category"
+
+    validation_code = fields.Text(
+        string="Validation Code",
+        help="Python code evaluated to validate the format of an "
+        "identification number belonging to this category. The number "
+        "being validated is available as the `id_number` variable; "
+        "the code must set a boolean `result` variable (True = valid, "
+        "False = invalid). Leave empty to accept any number for this "
+        "category.",
+    )
+    color = fields.Integer(
+        string="Color",
+        help="Color index used to visually distinguish this category, "
+        "e.g. in kanban or tag-like widgets.",
+    )

--- a/ssi_partner/models/res_partner_id_category.py
+++ b/ssi_partner/models/res_partner_id_category.py
@@ -18,7 +18,6 @@ class ResPartnerIdCategory(models.Model):
     _description = "Partner ID Category"
 
     validation_code = fields.Text(
-        string="Validation Code",
         help="Python code evaluated to validate the format of an "
         "identification number belonging to this category. The number "
         "being validated is available as the `id_number` variable; "
@@ -27,7 +26,6 @@ class ResPartnerIdCategory(models.Model):
         "category.",
     )
     color = fields.Integer(
-        string="Color",
         help="Color index used to visually distinguish this category, "
         "e.g. in kanban or tag-like widgets.",
     )

--- a/ssi_partner/models/res_partner_id_number.py
+++ b/ssi_partner/models/res_partner_id_number.py
@@ -26,7 +26,6 @@ class ResPartnerIdNumber(models.Model):
         "document (e.g. the National ID number).",
     )
     category_id = fields.Many2one(
-        string="Category",
         comodel_name="res_partner_id_category",
         required=True,
         ondelete="restrict",
@@ -35,7 +34,6 @@ class ResPartnerIdNumber(models.Model):
         "applied to the number.",
     )
     partner_id = fields.Many2one(
-        string="Partner",
         comodel_name="res.partner",
         required=True,
         ondelete="cascade",
@@ -49,26 +47,21 @@ class ResPartnerIdNumber(models.Model):
         "identification number, e.g. the government agency.",
     )
     date_issued = fields.Date(
-        string="Date Issued",
         help="Date this identification number was issued.",
     )
     valid_from = fields.Date(
-        string="Valid From",
         help="Date from which this identification number is "
         "considered valid. Leave empty if there is no start date.",
     )
     valid_until = fields.Date(
-        string="Valid Until",
         help="Date until which this identification number is "
         "considered valid. Leave empty if it does not expire.",
     )
     active = fields.Boolean(
-        string="Active",
         default=True,
         help="Uncheck to archive this identification number without deleting it.",
     )
     status = fields.Selection(
-        string="Status",
         selection=[
             ("draft", "Draft"),
             ("open", "Valid"),

--- a/ssi_partner/models/res_partner_id_number.py
+++ b/ssi_partner/models/res_partner_id_number.py
@@ -1,0 +1,128 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import datetime
+
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools.safe_eval import safe_eval
+
+
+class ResPartnerIdNumber(models.Model):
+    """Represents an identification number (e.g. National ID, Tax ID,
+    Driving License, Passport, Business Registration Number) assigned
+    to a partner. Each number belongs to a category
+    (``res_partner_id_category``) that determines how its format is
+    validated, and may carry its own validity period."""
+
+    _name = "res_partner_id_number"
+    _description = "Partner ID Number"
+    _order = "partner_id, category_id, name"
+
+    name = fields.Char(
+        string="Number",
+        required=True,
+        help="The identification number itself, as printed on the "
+        "document (e.g. the National ID number).",
+    )
+    category_id = fields.Many2one(
+        string="Category",
+        comodel_name="res_partner_id_category",
+        required=True,
+        ondelete="restrict",
+        help="Category of this identification number, e.g. National "
+        "ID, Tax ID, Driving License. Determines the validation rule "
+        "applied to the number.",
+    )
+    partner_id = fields.Many2one(
+        string="Partner",
+        comodel_name="res.partner",
+        required=True,
+        ondelete="cascade",
+        index=True,
+        help="Partner this identification number belongs to.",
+    )
+    partner_issued_id = fields.Many2one(
+        string="Issued By",
+        comodel_name="res.partner",
+        help="Partner (institution/authority) that issued this "
+        "identification number, e.g. the government agency.",
+    )
+    date_issued = fields.Date(
+        string="Date Issued",
+        help="Date this identification number was issued.",
+    )
+    valid_from = fields.Date(
+        string="Valid From",
+        help="Date from which this identification number is "
+        "considered valid. Leave empty if there is no start date.",
+    )
+    valid_until = fields.Date(
+        string="Valid Until",
+        help="Date until which this identification number is "
+        "considered valid. Leave empty if it does not expire.",
+    )
+    active = fields.Boolean(
+        string="Active",
+        default=True,
+        help="Uncheck to archive this identification number without deleting it.",
+    )
+    status = fields.Selection(
+        string="Status",
+        selection=[
+            ("draft", "Draft"),
+            ("open", "Valid"),
+            ("expired", "Expired"),
+        ],
+        compute="_compute_status",
+        store=True,
+        compute_sudo=True,
+        help="Validity status computed from the Valid From/Valid "
+        "Until dates compared to today: Draft when no validity period "
+        "is set at all, Expired once Valid Until has passed, Valid "
+        "otherwise.",
+    )
+
+    @api.depends("valid_from", "valid_until")
+    def _compute_status(self):
+        today = datetime.date.today()
+        for record in self:
+            if not record.valid_from and not record.valid_until:
+                record.status = "draft"
+            elif record.valid_until and record.valid_until < today:
+                record.status = "expired"
+            else:
+                record.status = "open"
+
+    @api.depends("name", "category_id.code")
+    def _compute_display_name(self):
+        for record in self:
+            record.display_name = f"[{record.category_id.code}] {record.name}"
+
+    def _get_id_number_validation_localdict(self):
+        self.ensure_one()
+        return {
+            "id_number": self.name,
+        }
+
+    def _check_id_number_format_condition(self):
+        self.ensure_one()
+        validation_code = self.category_id.validation_code
+        if not validation_code:
+            return True
+        localdict = self._get_id_number_validation_localdict()
+        safe_eval(validation_code, localdict, mode="exec")
+        return bool(localdict.get("result", True))
+
+    @api.constrains("name", "category_id")
+    def _check_id_number_format(self):
+        for record in self.sudo():
+            if not record._check_id_number_format_condition():
+                category_name = record.category_id.name
+                error_message = f"""
+Context: Create or update partner identification number
+Database ID: {record.id}
+Problem: Number "{record.name}" is not valid for category "{category_name}"
+Solution: Enter a number matching the format required by "{category_name}"
+"""
+                raise ValidationError(error_message)

--- a/ssi_partner/security/ir_model_access/res_partner_id_category.xml
+++ b/ssi_partner/security/ir_model_access/res_partner_id_category.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="res_partner_id_category_all_access" model="ir.model.access">
+        <field name="name">res_partner_id_category - all</field>
+        <field name="model_id" ref="model_res_partner_id_category" />
+        <field name="group_id" ref="base.group_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="res_partner_id_category_configurator_access" model="ir.model.access">
+        <field name="name">res_partner_id_category - configurator</field>
+        <field name="model_id" ref="model_res_partner_id_category" />
+        <field name="group_id" ref="res_partner_id_category_group" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+</odoo>

--- a/ssi_partner/security/ir_model_access/res_partner_id_number.xml
+++ b/ssi_partner/security/ir_model_access/res_partner_id_number.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <!-- res_partner_id_number is a plain model (not master data) whose
+         records are only ever edited through the res.partner form, so
+         it re-uses the res_partner_id_category configurator group
+         instead of a group of its own, per the backlog issue's design
+         decision (both models follow the two-line ACL pattern with an
+         existing configurator group). -->
+    <record id="res_partner_id_number_all_access" model="ir.model.access">
+        <field name="name">res_partner_id_number - all</field>
+        <field name="model_id" ref="model_res_partner_id_number" />
+        <field name="group_id" ref="base.group_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="res_partner_id_number_configurator_access" model="ir.model.access">
+        <field name="name">res_partner_id_number - configurator</field>
+        <field name="model_id" ref="model_res_partner_id_number" />
+        <field name="group_id" ref="res_partner_id_category_group" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+</odoo>

--- a/ssi_partner/security/res_groups/res_partner_id_category.xml
+++ b/ssi_partner/security/res_groups/res_partner_id_category.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <!-- Shared configurator group for both res_partner_id_category and
+         res_partner_id_number (see ir_model_access/res_partner_id_number.xml). -->
+    <record id="res_partner_id_category_group" model="res.groups">
+        <field name="name">ID Category</field>
+        <field name="privilege_id" ref="res_groups_privilege_partner" />
+        <field
+            name="user_ids"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+    </record>
+</odoo>

--- a/ssi_partner/tests/__init__.py
+++ b/ssi_partner/tests/__init__.py
@@ -13,3 +13,5 @@ from . import test_res_partner
 from . import test_res_partner_contact
 from . import test_res_partner_bank
 from . import test_partner_contact_group
+from . import test_res_partner_id_category
+from . import test_res_partner_id_number

--- a/ssi_partner/tests/test_data_res_partner_id_category.yaml
+++ b/ssi_partner/tests/test_data_res_partner_id_category.yaml
@@ -1,0 +1,61 @@
+scenarios:
+  - name: "Create ID category"
+    steps:
+      - step: "Create record"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "National ID"
+          code: "/"
+      - step: "Assert created"
+        action: "assert"
+        target: "category"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          name:
+            type: "value"
+            expected: "National ID"
+
+  - name: "Edit ID category name"
+    steps:
+      - step: "Create record"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "National ID"
+          code: "/"
+      - step: "Write new name"
+        action: "write"
+        target: "category"
+        values:
+          name: "National ID Card"
+      - step: "Assert name updated"
+        action: "assert"
+        target: "category"
+        asserts:
+          name:
+            type: "value"
+            expected: "National ID Card"
+
+  - name: "Delete ID category"
+    steps:
+      - step: "Create record"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "Temporary Category"
+          code: "/"
+      - step: "Delete record"
+        action: "unlink"
+        target: "category"
+      - step: "Verify deleted"
+        action: "search"
+        model: "res_partner_id_category"
+        domain: [["name", "=", "Temporary Category"]]
+        save_as: "result"
+        expect_count: 0

--- a/ssi_partner/tests/test_data_res_partner_id_number.yaml
+++ b/ssi_partner/tests/test_data_res_partner_id_number.yaml
@@ -1,0 +1,228 @@
+scenarios:
+  - name: "Create ID number on a category without validation code"
+    steps:
+      - step: "Create category without validation code"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "Membership Card"
+          code: "/"
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Jane Doe"
+      - step: "Create ID number"
+        action: "create"
+        model: "res_partner_id_number"
+        save_as: "id_number"
+        values:
+          name: "12345"
+          category_id: "REC: category.id"
+          partner_id: "REC: partner.id"
+      - step: "Assert saved and linked"
+        action: "assert"
+        target: "id_number"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          category_id:
+            type: "m2o"
+            expected: "REC: category"
+          partner_id:
+            type: "m2o"
+            expected: "REC: partner"
+
+  - name: "Number matching the category validation code is accepted"
+    steps:
+      - step: "Create category requiring an 8-character number"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "Passport"
+          code: "/"
+          validation_code: "result = len(id_number) == 8"
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Jane Doe"
+      - step: "Create ID number with a matching length"
+        action: "create"
+        model: "res_partner_id_number"
+        save_as: "id_number"
+        values:
+          name: "AB123456"
+          category_id: "REC: category.id"
+          partner_id: "REC: partner.id"
+      - step: "Assert saved"
+        action: "assert"
+        target: "id_number"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          name:
+            type: "value"
+            expected: "AB123456"
+
+  - name: "Status is expired when valid_until is in the past"
+    steps:
+      - step: "Create category"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "National ID"
+          code: "/"
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Jane Doe"
+      - step: "Create ID number already expired"
+        action: "create"
+        model: "res_partner_id_number"
+        save_as: "id_number"
+        values:
+          name: "12345"
+          category_id: "REC: category.id"
+          partner_id: "REC: partner.id"
+          valid_until: "EVAL: date.today() - timedelta(days=1)"
+      - step: "Assert status is expired"
+        action: "assert"
+        target: "id_number"
+        asserts:
+          status:
+            type: "value"
+            expected: "expired"
+
+  - name: "Status is draft when no validity dates are set"
+    steps:
+      - step: "Create category"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "National ID"
+          code: "/"
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Jane Doe"
+      - step: "Create ID number without validity dates"
+        action: "create"
+        model: "res_partner_id_number"
+        save_as: "id_number"
+        values:
+          name: "12345"
+          category_id: "REC: category.id"
+          partner_id: "REC: partner.id"
+      - step: "Assert status is draft"
+        action: "assert"
+        target: "id_number"
+        asserts:
+          status:
+            type: "value"
+            expected: "draft"
+
+  - name: "Partner id_numbers contains the created number"
+    steps:
+      - step: "Create category"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "National ID"
+          code: "/"
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Jane Doe"
+      - step: "Create ID number for the partner"
+        action: "create"
+        model: "res_partner_id_number"
+        save_as: "id_number"
+        values:
+          name: "12345"
+          category_id: "REC: category.id"
+          partner_id: "REC: partner.id"
+      - step: "Assert id_numbers contains the created number"
+        action: "assert"
+        target: "partner"
+        asserts:
+          id_numbers:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: id_number"
+
+  - name: "Deleting a partner cascades to its identification numbers"
+    steps:
+      - step: "Create category"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "National ID"
+          code: "/"
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Temporary Contact"
+      - step: "Create ID number for the partner"
+        action: "create"
+        model: "res_partner_id_number"
+        save_as: "id_number"
+        values:
+          name: "99999"
+          category_id: "REC: category.id"
+          partner_id: "REC: partner.id"
+      - step: "Delete the partner"
+        action: "unlink"
+        target: "partner"
+      - step: "Verify the ID number was cascaded"
+        action: "search"
+        model: "res_partner_id_number"
+        domain: [["name", "=", "99999"]]
+        save_as: "result"
+        expect_count: 0
+
+  - name: "Number violating the category validation code is rejected"
+    steps:
+      - step: "Create category requiring an 8-character number"
+        action: "create"
+        model: "res_partner_id_category"
+        save_as: "category"
+        values:
+          name: "Passport"
+          code: "/"
+          validation_code: "result = len(id_number) == 8"
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Jane Doe"
+      - step: "Create ID number with a wrong length must fail"
+        action: "create"
+        model: "res_partner_id_number"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Passport"
+        values:
+          name: "AB12"
+          category_id: "REC: category.id"
+          partner_id: "REC: partner.id"

--- a/ssi_partner/tests/test_res_partner_id_category.py
+++ b/ssi_partner/tests/test_res_partner_id_category.py
@@ -1,0 +1,12 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestResPartnerIdCategory(YamlTransactionCase):
+    def test_res_partner_id_category(self):
+        self.run_yaml_scenario("test_data_res_partner_id_category.yaml")

--- a/ssi_partner/tests/test_res_partner_id_number.py
+++ b/ssi_partner/tests/test_res_partner_id_number.py
@@ -1,0 +1,37 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+from psycopg2 import IntegrityError
+
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestResPartnerIdNumber(YamlTransactionCase):
+    def test_res_partner_id_number(self):
+        self.run_yaml_scenario("test_data_res_partner_id_number.yaml")
+
+    @mute_logger("odoo.sql_db")
+    def test_category_id_is_required(self):
+        """Python murni — pemicu P5 (L-22: `expect_error.type` di
+        `odoo-yaml-test` terbatas 12 nama hard-coded dan tidak termasuk
+        `psycopg2.IntegrityError`).
+
+        ``category_id`` adalah field ``required=True`` biasa (NOT NULL
+        di database), bukan ``@api.constrains``, sehingga
+        pelanggarannya lolos sampai ke database dan muncul sebagai
+        ``psycopg2.errors.NotNullViolation`` saat di-flush, bukan
+        salah satu dari 12 tipe yang didukung ``expect_error`` YAML.
+        """
+        partner = self.env["res.partner"].create({"name": "Contact A"})
+
+        with self.assertRaises(IntegrityError):
+            self.env["res_partner_id_number"].create(
+                {
+                    "name": "123456",
+                    "partner_id": partner.id,
+                }
+            )
+            self.env.cr.flush()

--- a/ssi_partner/views/res_partner.xml
+++ b/ssi_partner/views/res_partner.xml
@@ -88,6 +88,20 @@
                         <field name="secondary_industry_ids" widget="many2many_tags" />
                     </group>
                 </page>
+                <page name="ssi_partner_id_numbers" string="ID Numbers">
+                    <field name="id_numbers" context="{'default_partner_id': id}">
+                        <list editable="bottom">
+                            <field name="category_id" />
+                            <field name="name" />
+                            <field name="partner_issued_id" />
+                            <field name="date_issued" />
+                            <field name="valid_from" />
+                            <field name="valid_until" />
+                            <field name="status" readonly="1" />
+                            <field name="active" widget="boolean_toggle" />
+                        </list>
+                    </field>
+                </page>
             </notebook>
         </field>
     </record>

--- a/ssi_partner/views/res_partner_id_category.xml
+++ b/ssi_partner/views/res_partner_id_category.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="res_partner_id_category_view_search" model="ir.ui.view">
+        <field name="name">res_partner_id_category - search</field>
+        <field name="model">res_partner_id_category</field>
+        <field
+            name="inherit_id"
+            ref="ssi_master_data_mixin.mixin_master_data_view_search"
+        />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data />
+        </field>
+    </record>
+
+    <record id="res_partner_id_category_view_list" model="ir.ui.view">
+        <field name="name">res_partner_id_category - list</field>
+        <field name="model">res_partner_id_category</field>
+        <field
+            name="inherit_id"
+            ref="ssi_master_data_mixin.mixin_master_data_view_tree"
+        />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data />
+        </field>
+    </record>
+
+    <record id="res_partner_id_category_view_form" model="ir.ui.view">
+        <field name="name">res_partner_id_category - form</field>
+        <field name="model">res_partner_id_category</field>
+        <field
+            name="inherit_id"
+            ref="ssi_master_data_mixin.mixin_master_data_view_form"
+        />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data>
+                <xpath expr="//notebook/page[@name='note']" position="before">
+                    <page name="id_category_validation" string="Validation">
+                        <group name="id_category_validation_group">
+                            <field name="color" />
+                            <field name="validation_code" />
+                        </group>
+                    </page>
+                </xpath>
+            </data>
+        </field>
+    </record>
+
+    <record id="res_partner_id_category_action" model="ir.actions.act_window">
+        <field name="name">ID Categories</field>
+        <field name="res_model">res_partner_id_category</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem
+        id="res_partner_id_category_menu"
+        parent="menu_partner_configuration"
+        action="res_partner_id_category_action"
+        sequence="70"
+    />
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan mesin identifikasi partner ke modul `ssi_partner`:

- `res_partner_id_category` — master data (`mixin.master_data`) kategori nomor identitas (KTP, NPWP, SIM, paspor, NIB, dst.), dengan `validation_code` Python opsional per kategori dan field `color`.
- `res_partner_id_number` — nomor identitas milik partner: `category_id`, `partner_id` (cascade), `partner_issued_id`, `date_issued`, `valid_from`/`valid_until`, dan `status` (Draft/Valid/Expired) terkomputasi dari perbandingan tanggal hari ini.
- `res.partner.id_numbers` — One2many ke `res_partner_id_number`, ditampilkan sebagai tab "ID Numbers" pada form kontak.
- Validasi format nomor lewat `safe_eval` atas `validation_code` milik kategori (variabel `id_number`, hasil `result` boolean); kategori tanpa kode menerima nomor apa pun.
- Security: ACL dua baris untuk kedua model, memakai grup configurator baru `res_partner_id_category_group` (dipakai bersama oleh kedua model); `res_partner_id_category` masuk menu Configuration.

## Test plan

- [x] Unit test YAML (`odoo-yaml-test`) untuk `res_partner_id_category` (CRUD master data) dan `res_partner_id_number` (create tanpa validation code, create dengan validation code valid, compute status expired/draft, o2m `id_numbers` pada partner, cascade delete partner, penolakan format tidak valid, penolakan `category_id` kosong lewat test Python murni pemicu P5).
- [ ] CI hijau (`gh pr checks --watch`)

Closes #46