### PR TITLE
[ADD] ssi_partner: kemampuan bahasa partner (skala ILR)

### DIFF
--- a/ssi_partner/README.rst
+++ b/ssi_partner/README.rst
@@ -40,6 +40,14 @@ and the ``res_partner_id_number`` model, shown as an "ID Numbers" tab on
 ``res.partner``, tracking the number, issuing partner, issue date, and
 validity period (with a computed Draft/Valid/Expired ``status``).
 
+Adds a partner language proficiency mechanism: the ``partner_language``
+model, shown as an editable list on the "Personal Information" page of
+``res.partner`` (``language_ids``), records the languages spoken by an
+individual contact together with reading, writing, speaking, and
+listening proficiency on the 11-level ILR (Interagency Language
+Roundtable) scale. A given language can only be recorded once per
+partner.
+
 
 Installation
 ============

--- a/ssi_partner/__manifest__.py
+++ b/ssi_partner/__manifest__.py
@@ -35,6 +35,7 @@
         "security/ir_model_access/partner_contact_group.xml",
         "security/ir_model_access/res_partner_id_category.xml",
         "security/ir_model_access/res_partner_id_number.xml",
+        "security/ir_model_access/partner_language.xml",
         "menu.xml",
         "views/res_partner.xml",
         "views/company_ownership_type.xml",

--- a/ssi_partner/models/__init__.py
+++ b/ssi_partner/models/__init__.py
@@ -11,6 +11,7 @@ from . import res_partner_title  # noqa: F401
 from . import res_partner_bank  # noqa: F401
 from . import res_partner_id_category  # noqa: F401
 from . import res_partner_id_number  # noqa: F401
+from . import partner_language  # noqa: F401
 from . import res_partner  # noqa: F401
 from . import partner_contact_group  # noqa: F401
 from . import ir_actions_act_window  # noqa: F401

--- a/ssi_partner/models/partner_language.py
+++ b/ssi_partner/models/partner_language.py
@@ -1,0 +1,104 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+ILR_RATING_SELECTION = [
+    ("0", "0 - No Proficiency"),
+    ("0+", "0+ - Memorized Proficiency"),
+    ("1", "1 - Elementary Proficiency"),
+    ("1+", "1+ - Elementary Proficiency, Plus"),
+    ("2", "2 - Limited Working Proficiency"),
+    ("2+", "2+ - Limited Working Proficiency, Plus"),
+    ("3", "3 - General Professional Proficiency"),
+    ("3+", "3+ - General Professional Proficiency, Plus"),
+    ("4", "4 - Advanced Professional Proficiency"),
+    ("4+", "4+ - Advanced Professional Proficiency, Plus"),
+    ("5", "5 - Functionally Native Proficiency"),
+]
+
+
+class PartnerLanguage(models.Model):
+    """Records a language spoken by an individual partner, together
+    with its reading, writing, speaking, and listening proficiency on
+    the 11-level ILR (Interagency Language Roundtable) scale. Used for
+    recruitment, assignment, and partner assessment purposes. A given
+    language can only be recorded once per partner."""
+
+    _name = "partner_language"
+    _description = "Partner Language"
+    _order = "partner_id, name"
+
+    name = fields.Selection(
+        selection="_get_lang_selection",
+        string="Language",
+        required=True,
+        help="Language spoken by the partner, sourced from the "
+        "languages installed on this database.",
+    )
+    description = fields.Char(
+        help="Free-text note about this language proficiency, e.g. "
+        "the context in which it was learned.",
+    )
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        required=True,
+        ondelete="cascade",
+        index=True,
+        copy=False,
+        help="Partner this language proficiency record belongs to.",
+    )
+    read_rating = fields.Selection(
+        selection=ILR_RATING_SELECTION,
+        string="Reading",
+        required=True,
+        default="0",
+        help="Reading proficiency rated on the 11-level ILR scale.",
+    )
+    write_rating = fields.Selection(
+        selection=ILR_RATING_SELECTION,
+        string="Writing",
+        required=True,
+        default="0",
+        help="Writing proficiency rated on the 11-level ILR scale.",
+    )
+    speak_rating = fields.Selection(
+        selection=ILR_RATING_SELECTION,
+        string="Speaking",
+        required=True,
+        default="0",
+        help="Speaking proficiency rated on the 11-level ILR scale.",
+    )
+    listen_rating = fields.Selection(
+        selection=ILR_RATING_SELECTION,
+        string="Listening",
+        required=True,
+        default="0",
+        help="Listening proficiency rated on the 11-level ILR scale.",
+    )
+
+    @api.model
+    def _get_lang_selection(self):
+        return self.env["res.lang"].get_installed()
+
+    @api.constrains("partner_id", "name")
+    def _check_no_duplicate_language(self):
+        for record in self:
+            criteria = [
+                ("id", "!=", record.id),
+                ("partner_id", "=", record.partner_id.id),
+                ("name", "=", record.name),
+            ]
+            if self.search_count(criteria) > 0:
+                language_name = dict(record._get_lang_selection()).get(
+                    record.name, record.name
+                )
+                partner_name = record.partner_id.name
+                error_message = f"""
+Context: Create or update partner language
+Database ID: {record.id}
+Problem: Language "{language_name}" is already recorded for partner "{partner_name}"
+Solution: Choose a different language, or edit the existing record instead
+"""
+                raise UserError(error_message)

--- a/ssi_partner/models/res_partner.py
+++ b/ssi_partner/models/res_partner.py
@@ -175,6 +175,16 @@ class ResPartner(models.Model):
         "Registration Number.",
     )
 
+    # Languages
+    language_ids = fields.One2many(
+        string="Languages",
+        comodel_name="partner_language",
+        inverse_name="partner_id",
+        help="Languages spoken by this contact, each rated on the "
+        "11-level ILR scale for reading, writing, speaking, and "
+        "listening proficiency.",
+    )
+
     @api.depends("birthdate_date")
     def _compute_age(self):
         today = date.today()

--- a/ssi_partner/security/ir_model_access/partner_language.xml
+++ b/ssi_partner/security/ir_model_access/partner_language.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <!-- partner_language is transactional data owned by the partner
+         (edited directly from the res.partner form's Personal
+         Information page), not master data, so it has no
+         configurator group of its own — it re-uses the core
+         "Contact Creation" group instead, mirroring res.partner's
+         own ACL (base.group_user read-only + base.group_partner_manager
+         full access). -->
+    <record id="partner_language_all_access" model="ir.model.access">
+        <field name="name">partner_language - all</field>
+        <field name="model_id" ref="model_partner_language" />
+        <field name="group_id" ref="base.group_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="partner_language_manager_access" model="ir.model.access">
+        <field name="name">partner_language - manager</field>
+        <field name="model_id" ref="model_partner_language" />
+        <field name="group_id" ref="base.group_partner_manager" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+</odoo>

--- a/ssi_partner/tests/__init__.py
+++ b/ssi_partner/tests/__init__.py
@@ -15,3 +15,4 @@ from . import test_res_partner_bank
 from . import test_partner_contact_group
 from . import test_res_partner_id_category
 from . import test_res_partner_id_number
+from . import test_partner_language

--- a/ssi_partner/tests/test_data_partner_language.yaml
+++ b/ssi_partner/tests/test_data_partner_language.yaml
@@ -1,0 +1,204 @@
+setup:
+  steps:
+    - step: "Create partner A"
+      action: "create"
+      model: "res.partner"
+      save_as: "partner_a"
+      values:
+        name: "Jane Doe"
+
+scenarios:
+  - name: "Create language for a partner"
+    steps:
+      - step: "Create English language for partner A"
+        action: "create"
+        model: "partner_language"
+        save_as: "language"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+      - step: "Assert saved and linked to partner A"
+        action: "assert"
+        target: "language"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          partner_id:
+            type: "m2o"
+            expected: "REC: partner_a"
+
+  - name: "Ratings default to 0 when not provided"
+    steps:
+      - step: "Create language without explicit ratings"
+        action: "create"
+        model: "partner_language"
+        save_as: "language"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+      - step: "Assert all four ratings default to 0"
+        action: "assert"
+        target: "language"
+        asserts:
+          read_rating:
+            type: "value"
+            expected: "0"
+          write_rating:
+            type: "value"
+            expected: "0"
+          speak_rating:
+            type: "value"
+            expected: "0"
+          listen_rating:
+            type: "value"
+            expected: "0"
+
+  - name: "Write speak_rating stores the new value"
+    steps:
+      - step: "Create language"
+        action: "create"
+        model: "partner_language"
+        save_as: "language"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+      - step: "Write speak_rating to 3+"
+        action: "write"
+        target: "language"
+        values:
+          speak_rating: "3+"
+      - step: "Assert speak_rating updated"
+        action: "assert"
+        target: "language"
+        asserts:
+          speak_rating:
+            type: "value"
+            expected: "3+"
+
+  - name: "Same language is allowed for a different partner"
+    steps:
+      - step: "Create partner B"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner_b"
+        values:
+          name: "John Roe"
+      - step: "Create English language for partner A"
+        action: "create"
+        model: "partner_language"
+        save_as: "language_a"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+      - step: "Create English language for partner B"
+        action: "create"
+        model: "partner_language"
+        save_as: "language_b"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_b.id"
+      - step: "Assert partner B's language saved and linked"
+        action: "assert"
+        target: "language_b"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          partner_id:
+            type: "m2o"
+            expected: "REC: partner_b"
+
+  - name: "Partner language_ids contains the created language"
+    steps:
+      - step: "Create language for partner A"
+        action: "create"
+        model: "partner_language"
+        save_as: "language"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+      - step: "Assert language_ids contains the created record"
+        action: "assert"
+        target: "partner_a"
+        asserts:
+          language_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: language"
+
+  - name: "Deleting a language record removes it"
+    steps:
+      - step: "Create language for partner A"
+        action: "create"
+        model: "partner_language"
+        save_as: "language"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+      - step: "Delete the language record"
+        action: "unlink"
+        target: "language"
+      - step: "Verify no language remains for partner A"
+        action: "search"
+        model: "partner_language"
+        domain: [["partner_id", "=", "REC: partner_a.id"]]
+        save_as: "result"
+        expect_count: 0
+
+  - name: "Deleting a partner cascades to its languages"
+    steps:
+      - step: "Create temporary partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner_temp"
+        values:
+          name: "Temporary Contact"
+      - step: "Create language for the temporary partner"
+        action: "create"
+        model: "partner_language"
+        save_as: "language"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_temp.id"
+      - step: "Delete the temporary partner"
+        action: "unlink"
+        target: "partner_temp"
+      - step: "Verify the language was cascaded"
+        action: "search"
+        model: "partner_language"
+        domain: [["id", "=", "REC: language.id"]]
+        save_as: "result"
+        expect_count: 0
+
+  - name: "Duplicate language for the same partner is rejected"
+    steps:
+      - step: "Create first English language for partner A"
+        action: "create"
+        model: "partner_language"
+        save_as: "language"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+      - step: "Create duplicate English language for partner A must fail"
+        action: "create"
+        model: "partner_language"
+        expect_error:
+          type: "UserError"
+          message_contains: "English"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+
+  - name: "Rating value outside the ILR selection is rejected"
+    steps:
+      - step: "Create language with an out-of-selection rating must fail"
+        action: "create"
+        model: "partner_language"
+        expect_error:
+          type: "ValueError"
+        values:
+          name: "en_US"
+          partner_id: "REC: partner_a.id"
+          read_rating: "6"

--- a/ssi_partner/tests/test_partner_language.py
+++ b/ssi_partner/tests/test_partner_language.py
@@ -1,0 +1,12 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPartnerLanguage(YamlTransactionCase):
+    def test_partner_language(self):
+        self.run_yaml_scenario("test_data_partner_language.yaml")

--- a/ssi_partner/views/res_partner.xml
+++ b/ssi_partner/views/res_partner.xml
@@ -61,6 +61,17 @@
                             required="contact_type == 'attached'"
                         />
                     </group>
+                    <separator string="Languages" />
+                    <field name="language_ids" context="{'default_partner_id': id}">
+                        <list editable="bottom">
+                            <field name="name" />
+                            <field name="description" />
+                            <field name="read_rating" />
+                            <field name="write_rating" />
+                            <field name="speak_rating" />
+                            <field name="listen_rating" />
+                        </list>
+                    </field>
                 </page>
                 <page
                     name="ssi_partner_other_positions"


### PR DESCRIPTION
## Ringkasan

Menambahkan model `partner_language` untuk mencatat beberapa bahasa per partner individual, masing-masing dengan tingkat kemampuan membaca, menulis, berbicara, dan menyimak pada skala ILR 11 tingkat (`0`, `0+`, `1`, `1+`, `2`, `2+`, `3`, `3+`, `4`, `4+`, `5`).

- Model baru `partner_language` (`_order = "partner_id, name"`), field `name` (Selection dari `res.lang.get_installed()`), `description`, `partner_id` (M2O `res.partner`, `ondelete="cascade"`), dan empat field rating (`read_rating`, `write_rating`, `speak_rating`, `listen_rating`), semuanya `required=True`, `default="0"`.
- `@api.constrains("partner_id", "name")` menolak bahasa yang sama dua kali untuk satu partner (`UserError`, menyebut nama bahasanya).
- `res.partner.language_ids`: One2many baru, ditampilkan sebagai list editable pada halaman notebook "Personal Information".
- Security: dua baris ACL mengikuti pola parent (`res.partner`) — `base.group_user` read-only, `base.group_partner_manager` full CRUD — tanpa membuat group configurator baru (data transaksional milik partner, bukan master data konfigurasi).
- Unit test skenario YAML (`odoo-yaml-test`) mencakup seluruh Kriteria Penerimaan & Skenario Uji di issue.

Closes #47

## Test plan

- [x] CI: lint (pre-commit) hijau
- [ ] CI: unit test (`odoo-yaml-test`) hijau