### PR TITLE
[UPD] ssi_partner_data_privacy_consent: res.partner.consent (append-only)

### DIFF
--- a/ssi_partner_data_privacy_consent/__manifest__.py
+++ b/ssi_partner_data_privacy_consent/__manifest__.py
@@ -19,6 +19,7 @@
         "menu.xml",
         "views/partner_consent_purpose_views.xml",
         "views/partner_consent_notice_views.xml",
+        "views/res_partner_views.xml",
     ],
     "demo": [],
     "contributors": [

--- a/ssi_partner_data_privacy_consent/models/__init__.py
+++ b/ssi_partner_data_privacy_consent/models/__init__.py
@@ -5,4 +5,6 @@
 from . import (
     partner_consent_purpose,
     partner_consent_notice,
+    res_partner_consent,
+    res_partner,
 )

--- a/ssi_partner_data_privacy_consent/models/res_partner.py
+++ b/ssi_partner_data_privacy_consent/models/res_partner.py
@@ -1,0 +1,48 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _name = "res.partner"
+    _inherit = "res.partner"
+
+    consent_ids = fields.One2many(
+        string="Data Privacy Consents",
+        comodel_name="res.partner.consent",
+        inverse_name="partner_id",
+        readonly=True,
+        help="Append-only log of privacy consent events for this partner.",
+    )
+    active_consent_purpose_ids = fields.Many2many(
+        string="Active Consent Purposes",
+        comodel_name="partner_consent_purpose",
+        compute="_compute_active_consent_purpose_ids",
+        store=False,
+        compute_sudo=True,
+        help="Purposes whose most recent consent event is a grant. Derived "
+        "from the consent log, not stored.",
+    )
+
+    @api.depends(
+        "consent_ids",
+        "consent_ids.consent_type",
+        "consent_ids.purpose_id",
+        "consent_ids.consent_date",
+    )
+    def _compute_active_consent_purpose_ids(self):
+        for record in self:
+            active = self.env["partner_consent_purpose"]
+            seen = set()
+            # consent_ids is ordered by "consent_date desc, id", so the first
+            # event encountered per purpose is its most recent event.
+            for consent in record.consent_ids:
+                purpose = consent.purpose_id
+                if purpose.id in seen:
+                    continue
+                seen.add(purpose.id)
+                if consent.consent_type == "grant":
+                    active |= purpose
+            record.active_consent_purpose_ids = active

--- a/ssi_partner_data_privacy_consent/models/res_partner_consent.py
+++ b/ssi_partner_data_privacy_consent/models/res_partner_consent.py
@@ -1,0 +1,108 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class ResPartnerConsent(models.Model):
+    """
+    Append-only log of privacy consent events for a data subject
+    (res.partner). Each record captures a single grant or withdrawal of one
+    processing purpose against one privacy notice version, together with the
+    technical evidence of the event. Records are immutable once created:
+    withdrawing a consent is done by creating a new record with
+    consent_type "withdraw", never by modifying an existing record. The set
+    of currently active purposes is derived (not stored) from this log.
+    """
+
+    _name = "res.partner.consent"
+    _description = "res.partner - Data Privacy Consent"
+    _order = "consent_date desc, id"
+
+    partner_id = fields.Many2one(
+        string="Partner",
+        comodel_name="res.partner",
+        ondelete="cascade",
+        required=True,
+        help="Data subject whose consent this record captures.",
+    )
+    notice_id = fields.Many2one(
+        string="Privacy Notice",
+        comodel_name="partner_consent_notice",
+        ondelete="restrict",
+        required=True,
+        help="Privacy notice version presented to and agreed by the data "
+        "subject at the time of this consent event.",
+    )
+    purpose_id = fields.Many2one(
+        string="Purpose",
+        comodel_name="partner_consent_purpose",
+        ondelete="restrict",
+        required=True,
+        help="Data-processing purpose granted or withdrawn by this consent "
+        "event. One purpose per record allows per-purpose granularity and "
+        "withdrawal.",
+    )
+    consent_type = fields.Selection(
+        string="Consent Type",
+        selection=[
+            ("grant", "Granted"),
+            ("withdraw", "Withdrawn"),
+        ],
+        required=True,
+        default="grant",
+        help="Whether this event grants or withdraws consent for the purpose.",
+    )
+    consent_date = fields.Datetime(
+        string="Consent Date",
+        required=True,
+        default=fields.Datetime.now,
+        help="Date and time at which the consent event occurred.",
+    )
+    channel = fields.Selection(
+        string="Channel",
+        selection=[
+            ("portal", "Portal"),
+            ("manual", "Back Office"),
+            ("import", "Import"),
+        ],
+        required=True,
+        default="portal",
+        help="Channel through which this consent event was captured.",
+    )
+    evidence_ip = fields.Char(
+        string="Evidence IP",
+        help="IP address recorded as technical evidence of the consent event.",
+    )
+    evidence_user_agent = fields.Char(
+        string="Evidence User Agent",
+        help="Browser user agent recorded as technical evidence of the "
+        "consent event.",
+    )
+    note = fields.Text(
+        string="Note",
+        help="Free-text note about this consent event.",
+    )
+
+    def write(self, vals):
+        if not self.env.su:
+            raise UserError(
+                _(
+                    "Data privacy consent records are immutable and cannot be "
+                    "modified. To withdraw a consent, create a new record with "
+                    "consent type Withdrawn."
+                )
+            )
+        return super(ResPartnerConsent, self).write(vals)
+
+    def unlink(self):
+        if not self.env.su:
+            raise UserError(
+                _(
+                    "Data privacy consent records are immutable and cannot be "
+                    "deleted."
+                )
+            )
+        return super(ResPartnerConsent, self).unlink()

--- a/ssi_partner_data_privacy_consent/security/ir.model.access.csv
+++ b/ssi_partner_data_privacy_consent/security/ir.model.access.csv
@@ -3,3 +3,4 @@ access_partner_consent_purpose_configurator,partner_consent_purpose - configurat
 access_partner_consent_purpose_all,partner_consent_purpose - all,model_partner_consent_purpose,,1,0,0,0
 access_partner_consent_notice_configurator,partner_consent_notice - configurator,model_partner_consent_notice,partner_consent_notice_group,1,1,1,1
 access_partner_consent_notice_all,partner_consent_notice - all,model_partner_consent_notice,,1,0,0,0
+access_res_partner_consent_all,res.partner.consent - all,model_res_partner_consent,,1,1,1,1

--- a/ssi_partner_data_privacy_consent/tests/test_data_privacy_consent.yaml
+++ b/ssi_partner_data_privacy_consent/tests/test_data_privacy_consent.yaml
@@ -209,3 +209,335 @@ scenarios:
           name: "Notice Missing Body"
           code: "NOTICE-07"
           version: "1.0"
+
+  - name: "Partner Consent - Grant activates purpose"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Consent Subject Grant"
+
+      - step: "Create purpose"
+        action: "create"
+        model: "partner_consent_purpose"
+        save_as: "purpose"
+        values:
+          name: "Marketing Communication"
+          code: "CONSENT-PURPOSE-G1"
+
+      - step: "Create notice"
+        action: "create"
+        model: "partner_consent_notice"
+        save_as: "notice"
+        values:
+          name: "Grant Privacy Notice"
+          code: "CONSENT-NOTICE-G1"
+          version: "1.0"
+          body: "Notice body for grant."
+
+      - step: "Create grant consent"
+        action: "create"
+        model: "res.partner.consent"
+        save_as: "consent"
+        values:
+          partner_id: "REC: partner.id"
+          notice_id: "REC: notice.id"
+          purpose_id: "REC: purpose.id"
+          consent_type: "grant"
+          consent_date: "2026-01-01 00:00:00"
+          channel: "portal"
+
+      - step: "Assert grant consent created"
+        action: "assert"
+        target: "consent"
+        asserts:
+          partner_id:
+            type: "m2o"
+            expected: "REC: partner"
+          purpose_id:
+            type: "m2o"
+            expected: "REC: purpose"
+          notice_id:
+            type: "m2o"
+            expected: "REC: notice"
+          consent_type:
+            type: "value"
+            expected: "grant"
+
+      - step: "Assert purpose is active on partner"
+        action: "assert"
+        target: "partner"
+        refresh: true
+        asserts:
+          active_consent_purpose_ids:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: purpose"
+
+  - name: "Partner Consent - Later withdraw deactivates purpose"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Consent Subject Withdraw"
+
+      - step: "Create purpose"
+        action: "create"
+        model: "partner_consent_purpose"
+        save_as: "purpose"
+        values:
+          name: "Profiling"
+          code: "CONSENT-PURPOSE-W1"
+
+      - step: "Create notice"
+        action: "create"
+        model: "partner_consent_notice"
+        save_as: "notice"
+        values:
+          name: "Withdraw Privacy Notice"
+          code: "CONSENT-NOTICE-W1"
+          version: "1.0"
+          body: "Notice body for withdraw."
+
+      - step: "Create grant consent (earlier)"
+        action: "create"
+        model: "res.partner.consent"
+        save_as: "grant_consent"
+        values:
+          partner_id: "REC: partner.id"
+          notice_id: "REC: notice.id"
+          purpose_id: "REC: purpose.id"
+          consent_type: "grant"
+          consent_date: "2026-01-01 00:00:00"
+          channel: "portal"
+
+      - step: "Assert purpose active after grant"
+        action: "assert"
+        target: "partner"
+        refresh: true
+        asserts:
+          active_consent_purpose_ids:
+            type: "m2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Create withdraw consent (later)"
+        action: "create"
+        model: "res.partner.consent"
+        save_as: "withdraw_consent"
+        values:
+          partner_id: "REC: partner.id"
+          notice_id: "REC: notice.id"
+          purpose_id: "REC: purpose.id"
+          consent_type: "withdraw"
+          consent_date: "2026-02-01 00:00:00"
+          channel: "portal"
+
+      - step: "Assert purpose no longer active after withdraw"
+        action: "assert"
+        target: "partner"
+        refresh: true
+        asserts:
+          active_consent_purpose_ids:
+            type: "m2m"
+            check: "count"
+            expected_count: 0
+
+  - name: "Partner Consent - Record is immutable on write"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Consent Subject Immutable Write"
+
+      - step: "Create purpose"
+        action: "create"
+        model: "partner_consent_purpose"
+        save_as: "purpose"
+        values:
+          name: "Service Delivery"
+          code: "CONSENT-PURPOSE-IW1"
+
+      - step: "Create notice"
+        action: "create"
+        model: "partner_consent_notice"
+        save_as: "notice"
+        values:
+          name: "Immutable Write Notice"
+          code: "CONSENT-NOTICE-IW1"
+          version: "1.0"
+          body: "Notice body."
+
+      - step: "Create consent"
+        action: "create"
+        model: "res.partner.consent"
+        save_as: "consent"
+        values:
+          partner_id: "REC: partner.id"
+          notice_id: "REC: notice.id"
+          purpose_id: "REC: purpose.id"
+          consent_type: "grant"
+
+      - step: "Non-superuser cannot modify the consent record"
+        action: "write"
+        target: "consent"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+        values:
+          note: "attempt to modify"
+
+  - name: "Partner Consent - Record is immutable on unlink"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Consent Subject Immutable Unlink"
+
+      - step: "Create purpose"
+        action: "create"
+        model: "partner_consent_purpose"
+        save_as: "purpose"
+        values:
+          name: "Analytics"
+          code: "CONSENT-PURPOSE-IU1"
+
+      - step: "Create notice"
+        action: "create"
+        model: "partner_consent_notice"
+        save_as: "notice"
+        values:
+          name: "Immutable Unlink Notice"
+          code: "CONSENT-NOTICE-IU1"
+          version: "1.0"
+          body: "Notice body."
+
+      - step: "Create consent"
+        action: "create"
+        model: "res.partner.consent"
+        save_as: "consent"
+        values:
+          partner_id: "REC: partner.id"
+          notice_id: "REC: notice.id"
+          purpose_id: "REC: purpose.id"
+          consent_type: "grant"
+
+      - step: "Non-superuser cannot delete the consent record"
+        action: "unlink"
+        target: "consent"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+
+  - name: "Partner Consent - Purpose is required"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Consent Subject Missing Purpose"
+
+      - step: "Create notice"
+        action: "create"
+        model: "partner_consent_notice"
+        save_as: "notice"
+        values:
+          name: "Missing Purpose Notice"
+          code: "CONSENT-NOTICE-MP1"
+          version: "1.0"
+          body: "Notice body."
+
+      - step: "Create consent without purpose must fail"
+        action: "form"
+        model: "res.partner.consent"
+        expect_error:
+          type: "AssertionError"
+          message_contains: "purpose"
+        values:
+          partner_id: "REC: partner"
+          notice_id: "REC: notice"
+
+  - name: "Partner Consent - Notice is required"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Consent Subject Missing Notice"
+
+      - step: "Create purpose"
+        action: "create"
+        model: "partner_consent_purpose"
+        save_as: "purpose"
+        values:
+          name: "Support"
+          code: "CONSENT-PURPOSE-MN1"
+
+      - step: "Create consent without notice must fail"
+        action: "form"
+        model: "res.partner.consent"
+        expect_error:
+          type: "AssertionError"
+          message_contains: "notice"
+        values:
+          partner_id: "REC: partner"
+          purpose_id: "REC: purpose"
+
+  - name: "Partner Consent - Deleting partner cascades consents"
+    steps:
+      - step: "Create partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Consent Subject Cascade"
+
+      - step: "Create purpose"
+        action: "create"
+        model: "partner_consent_purpose"
+        save_as: "purpose"
+        values:
+          name: "Cascade Purpose"
+          code: "CONSENT-PURPOSE-C1"
+
+      - step: "Create notice"
+        action: "create"
+        model: "partner_consent_notice"
+        save_as: "notice"
+        values:
+          name: "Cascade Notice"
+          code: "CONSENT-NOTICE-C1"
+          version: "1.0"
+          body: "Notice body."
+
+      - step: "Create consent"
+        action: "create"
+        model: "res.partner.consent"
+        save_as: "consent"
+        values:
+          partner_id: "REC: partner.id"
+          notice_id: "REC: notice.id"
+          purpose_id: "REC: purpose.id"
+          consent_type: "grant"
+
+      - step: "Delete the partner"
+        action: "unlink"
+        target: "partner"
+
+      - step: "Assert consents of the partner are gone"
+        action: "search"
+        model: "res.partner.consent"
+        domain: [["notice_id.code", "=", "CONSENT-NOTICE-C1"]]
+        save_as: "remaining"
+        expect_count: 0

--- a/ssi_partner_data_privacy_consent/views/res_partner_views.xml
+++ b/ssi_partner_data_privacy_consent/views/res_partner_views.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="res_partner_view_form" model="ir.ui.view">
+        <field name="name">res.partner - data privacy consent form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="priority" eval="20" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales_purchases']" position="after">
+                <page name="data_privacy_consent" string="Data Privacy Consent">
+                    <group name="active_consent" colspan="4" col="2">
+                        <field
+                            name="active_consent_purpose_ids"
+                            widget="many2many_tags"
+                            readonly="1"
+                        />
+                    </group>
+                    <separator string="Consent Log" />
+                    <field name="consent_ids" readonly="1">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="consent_date" />
+                            <field name="purpose_id" />
+                            <field name="notice_id" />
+                            <field name="consent_type" />
+                            <field name="channel" />
+                        </tree>
+                        <form>
+                            <group name="consent_1" colspan="4" col="2">
+                                <group name="consent_1_1" colspan="1" col="2">
+                                    <field name="consent_date" />
+                                    <field name="purpose_id" />
+                                    <field name="notice_id" />
+                                    <field name="consent_type" />
+                                    <field name="channel" />
+                                </group>
+                                <group name="consent_1_2" colspan="1" col="2">
+                                    <field name="evidence_ip" />
+                                    <field name="evidence_user_agent" />
+                                </group>
+                            </group>
+                            <group name="consent_2" colspan="4" col="1">
+                                <field name="note" />
+                            </group>
+                        </form>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambah model detail **`res.partner.consent`** pada modul `ssi_partner_data_privacy_consent` sebagai log **append-only** persetujuan privasi per partner, sesuai UU PDP.

### Perubahan
- Model `res.partner.consent` (child `res.partner`, `_order = "consent_date desc, id"`): field `partner_id` (cascade), `notice_id`/`purpose_id` (restrict), `consent_type` (grant/withdraw), `consent_date`, `channel`, `evidence_ip`, `evidence_user_agent`, `note`.
- **Immutability**: override `write()`/`unlink()` menolak user non-superuser (`UserError`). Penarikan = create record baru `withdraw`.
- Extend `res.partner`: One2many `consent_ids` + compute `active_consent_purpose_ids` (`store=False`, `compute_sudo=True`) yang menurunkan tujuan yang event terakhirnya `grant`.
- Page read-only "Data Privacy Consent" di form `res.partner`.
- ACL child tanpa group (mirror `res.partner.evaluation_result`).
- Skenario unit test `odoo-yaml-test`: grant mengaktifkan purpose, withdraw menonaktifkan, immutability write/unlink, required purpose/notice, cascade delete partner.

Closes #57