### PR TITLE
[UPD] ssi_partner - Tambah field relasi keluarga pada res.partner (group Family)

### DIFF
--- a/ssi_partner/models/res_partner.py
+++ b/ssi_partner/models/res_partner.py
@@ -68,6 +68,49 @@ class ResPartner(models.Model):
         string="Spouse Birthdate",
         required=False,
     )
+    father_id = fields.Many2one(
+        string="Father",
+        comodel_name="res.partner",
+        domain=[("is_company", "=", False)],
+        required=False,
+        help="Father of this contact. Only individual contacts can be selected.",
+    )
+    mother_id = fields.Many2one(
+        string="Mother",
+        comodel_name="res.partner",
+        domain=[("is_company", "=", False)],
+        required=False,
+        help="Mother of this contact. Only individual contacts can be selected.",
+    )
+    guardian_id = fields.Many2one(
+        string="Guardian",
+        comodel_name="res.partner",
+        domain=[("is_company", "=", False)],
+        required=False,
+        help="Legal guardian of this contact. Only individual contacts can be "
+        "selected.",
+    )
+    spouse_id = fields.Many2one(
+        string="Spouse",
+        comodel_name="res.partner",
+        domain=[("is_company", "=", False)],
+        required=False,
+        help="Spouse of this contact, linked as a partner record. Only "
+        "individual contacts can be selected. This does not replace or "
+        "synchronize with Spouse Complete Name/Spouse Birthdate.",
+    )
+    children_ids = fields.Many2many(
+        string="Children",
+        comodel_name="res.partner",
+        relation="rel_partner_2_children",
+        column1="parent_id",
+        column2="children_id",
+        domain=[("is_company", "=", False)],
+        required=False,
+        help="Children of this contact. Only individual contacts can be "
+        "selected. Many2many is used because a single contact record cannot "
+        "hold a dedicated parent field for both father and mother.",
+    )
 
     def action_open_contact_address(self):
         for record in self.sudo():

--- a/ssi_partner/tests/__init__.py
+++ b/ssi_partner/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_ssi_partner  # noqa: F401
+from . import test_res_partner_family  # noqa: F401

--- a/ssi_partner/tests/test_data_res_partner_family.yaml
+++ b/ssi_partner/tests/test_data_res_partner_family.yaml
@@ -1,0 +1,331 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "Family - All Family Fields Set on Create"
+    steps:
+      - step: "Create father"
+        action: "create"
+        model: "res.partner"
+        save_as: "father"
+        values:
+          name: "Test Father"
+          is_company: false
+
+      - step: "Create mother"
+        action: "create"
+        model: "res.partner"
+        save_as: "mother"
+        values:
+          name: "Test Mother"
+          is_company: false
+
+      - step: "Create guardian"
+        action: "create"
+        model: "res.partner"
+        save_as: "guardian"
+        values:
+          name: "Test Guardian"
+          is_company: false
+
+      - step: "Create spouse"
+        action: "create"
+        model: "res.partner"
+        save_as: "spouse"
+        values:
+          name: "Test Spouse"
+          is_company: false
+
+      - step: "Create first child"
+        action: "create"
+        model: "res.partner"
+        save_as: "child_1"
+        values:
+          name: "Test Child 1"
+          is_company: false
+
+      - step: "Create second child"
+        action: "create"
+        model: "res.partner"
+        save_as: "child_2"
+        values:
+          name: "Test Child 2"
+          is_company: false
+
+      - step: "Create contact X with all family fields set"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_x"
+        values:
+          name: "Test Contact X"
+          is_company: false
+          father_id: "REC: father.id"
+          mother_id: "REC: mother.id"
+          guardian_id: "REC: guardian.id"
+          spouse_id: "REC: spouse.id"
+          children_ids: [[6, 0, ["REC: child_1.id", "REC: child_2.id"]]]
+
+      - step: "Assert family many2one fields"
+        action: "assert"
+        target: "contact_x"
+        asserts:
+          father_id:
+            type: "m2o"
+            expected: "REC: father"
+          mother_id:
+            type: "m2o"
+            expected: "REC: mother"
+          guardian_id:
+            type: "m2o"
+            expected: "REC: guardian"
+          spouse_id:
+            type: "m2o"
+            expected: "REC: spouse"
+
+      - step: "Assert children_ids contains exactly both children"
+        action: "assert"
+        target: "contact_x"
+        asserts:
+          children_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: child_1"
+              - "REC: child_2"
+
+  - name: "Family - Contact Without Family Fields is Empty"
+    steps:
+      - step: "Create contact without any family field"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_no_family"
+        values:
+          name: "Test Contact No Family"
+          is_company: false
+
+      - step: "Assert family many2one fields are falsy"
+        action: "assert"
+        target: "contact_no_family"
+        asserts:
+          father_id:
+            type: "value"
+            operator: "is_falsy"
+          mother_id:
+            type: "value"
+            operator: "is_falsy"
+          guardian_id:
+            type: "value"
+            operator: "is_falsy"
+          spouse_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert children_ids is empty"
+        action: "assert"
+        target: "contact_no_family"
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+  - name: "Family - Write Spouse Changes to New Record"
+    steps:
+      - step: "Create first spouse candidate"
+        action: "create"
+        model: "res.partner"
+        save_as: "spouse_1"
+        values:
+          name: "Test Spouse 1"
+          is_company: false
+
+      - step: "Create second spouse candidate"
+        action: "create"
+        model: "res.partner"
+        save_as: "spouse_2"
+        values:
+          name: "Test Spouse 2"
+          is_company: false
+
+      - step: "Create contact with first spouse"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_spouse"
+        values:
+          name: "Test Contact Spouse"
+          is_company: false
+          spouse_id: "REC: spouse_1.id"
+
+      - step: "Assert spouse_id is first spouse"
+        action: "assert"
+        target: "contact_spouse"
+        asserts:
+          spouse_id:
+            type: "m2o"
+            expected: "REC: spouse_1"
+
+      - step: "Write spouse_id to second spouse"
+        action: "write"
+        target: "contact_spouse"
+        values:
+          spouse_id: "REC: spouse_2.id"
+
+      - step: "Assert spouse_id changed to second spouse"
+        action: "assert"
+        target: "contact_spouse"
+        asserts:
+          spouse_id:
+            type: "m2o"
+            expected: "REC: spouse_2"
+
+  - name: "Family - Same Child Linked to Both Father and Mother (Many2many)"
+    steps:
+      - step: "Create father"
+        action: "create"
+        model: "res.partner"
+        save_as: "father"
+        values:
+          name: "Test Father"
+          is_company: false
+
+      - step: "Create mother"
+        action: "create"
+        model: "res.partner"
+        save_as: "mother"
+        values:
+          name: "Test Mother"
+          is_company: false
+
+      - step: "Create shared child"
+        action: "create"
+        model: "res.partner"
+        save_as: "child"
+        values:
+          name: "Test Shared Child"
+          is_company: false
+
+      - step: "Link child to father's children_ids"
+        action: "write"
+        target: "father"
+        values:
+          children_ids: [[6, 0, ["REC: child.id"]]]
+
+      - step: "Link child to mother's children_ids"
+        action: "write"
+        target: "mother"
+        values:
+          children_ids: [[6, 0, ["REC: child.id"]]]
+
+      - step: "Assert father's children_ids contains the shared child"
+        action: "assert"
+        target: "father"
+        asserts:
+          children_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: child"
+
+      - step: "Assert mother's children_ids contains the shared child"
+        action: "assert"
+        target: "mother"
+        asserts:
+          children_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: child"
+
+  - name: "Family - Write Children_ids Removes One Child"
+    steps:
+      - step: "Create first child"
+        action: "create"
+        model: "res.partner"
+        save_as: "child_1"
+        values:
+          name: "Test Child 1"
+          is_company: false
+
+      - step: "Create second child"
+        action: "create"
+        model: "res.partner"
+        save_as: "child_2"
+        values:
+          name: "Test Child 2"
+          is_company: false
+
+      - step: "Create parent with both children"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent"
+        values:
+          name: "Test Parent"
+          is_company: false
+          children_ids: [[6, 0, ["REC: child_1.id", "REC: child_2.id"]]]
+
+      - step: "Assert both children are linked"
+        action: "assert"
+        target: "parent"
+        asserts:
+          children_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: child_1"
+              - "REC: child_2"
+
+      - step: "Write children_ids to keep only the second child"
+        action: "write"
+        target: "parent"
+        values:
+          children_ids: [[6, 0, ["REC: child_2.id"]]]
+
+      - step: "Assert children_ids now contains only the second child"
+        action: "assert"
+        target: "parent"
+        asserts:
+          children_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: child_2"
+
+  - name: "Family - Unlink Guardian Sets guardian_id Falsy (ondelete=set null)"
+    steps:
+      - step: "Create guardian"
+        action: "create"
+        model: "res.partner"
+        save_as: "guardian"
+        values:
+          name: "Test Guardian To Delete"
+          is_company: false
+
+      - step: "Create contact pointing to the guardian"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_guarded"
+        values:
+          name: "Test Contact Guarded"
+          is_company: false
+          guardian_id: "REC: guardian.id"
+
+      - step: "Assert guardian_id is set"
+        action: "assert"
+        target: "contact_guarded"
+        asserts:
+          guardian_id:
+            type: "m2o"
+            expected: "REC: guardian"
+
+      - step: "Unlink the guardian record"
+        action: "unlink"
+        target: "guardian"
+
+      - step: "Assert guardian_id on the pointing contact becomes falsy"
+        action: "assert"
+        target: "contact_guarded"
+        refresh: true
+        asserts:
+          guardian_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_partner/tests/test_res_partner_family.py
+++ b/ssi_partner/tests/test_res_partner_family.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestResPartnerFamily(YamlTransactionCase):
+    def test_res_partner_family(self):
+        self.run_yaml_scenario("test_data_res_partner_family.yaml")

--- a/ssi_partner/views/res_partner_views.xml
+++ b/ssi_partner/views/res_partner_views.xml
@@ -146,6 +146,15 @@
                     attrs="{'invisible': [('marital', 'not in', ['married', 'cohabitant'])]}"
                 />
         </xpath>
+        <xpath expr="//group[@name='personal_information_group']" position="after">
+            <group name="family" string="Family">
+                <field name="father_id" />
+                <field name="mother_id" />
+                <field name="guardian_id" />
+                <field name="spouse_id" />
+                <field name="children_ids" widget="many2many_tags" />
+            </group>
+        </xpath>
     </field>
 </record>
 


### PR DESCRIPTION
## Ringkasan

Menambahkan field relasi keluarga pada model `res.partner` di modul `ssi_partner`:

- `father_id`, `mother_id`, `guardian_id`, `spouse_id` — Many2one ke `res.partner`
  (`domain=[("is_company", "=", False)]`).
- `children_ids` — Many2many ke `res.partner` lewat tabel relasi sendiri
  `rel_partner_2_children` (`column1="parent_id"`, `column2="children_id"`).

Kelima field ditampilkan dalam group baru **Family** di dalam page **Personal
Information** yang sudah ada (`ssi_partner.personal_information`, inherit dari
`partner_contact_personal_information_page.personal_information`) — tidak ada
`ir.ui.view` baru, XML ID lama tidak berubah.

Field `spouse_complete_name` dan `spouse_birthdate` tetap apa adanya, tanpa
compute/onchange yang menyinkronkannya dengan `spouse_id`.

## Unit Test

Skenario `odoo-yaml-test` baru (`tests/test_data_res_partner_family.yaml`,
dijalankan lewat `tests/test_res_partner_family.py`):

- Create contact dengan seluruh field keluarga terisi → assert kelima field.
- Create contact tanpa field keluarga → seluruh m2o falsy, `children_ids` kosong.
- Write `spouse_id` ke record lain → nilai berubah.
- Satu anak yang sama ditautkan ke `children_ids` ayah **dan** ibu (membuktikan
  pilihan Many2many).
- Write `children_ids` untuk mengeluarkan satu anak.
- Unlink record `guardian_id` → `guardian_id` pada kontak penunjuk menjadi falsy
  (membuktikan `ondelete="set null"`).

Closes #60