### PR TITLE
[UPD] ssi_partner: sinkronkan father_id/mother_id dengan children_ids, tambah ward_ids & link_child

### DIFF
--- a/ssi_partner/models/res_partner.py
+++ b/ssi_partner/models/res_partner.py
@@ -2,7 +2,8 @@
 # Copyright 2023 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -111,6 +112,128 @@ class ResPartner(models.Model):
         "selected. Many2many is used because a single contact record cannot "
         "hold a dedicated parent field for both father and mother.",
     )
+    ward_ids = fields.One2many(
+        string="Wards",
+        comodel_name="res.partner",
+        inverse_name="guardian_id",
+        help="Contacts that have this contact set as their legal guardian. "
+        "This is the automatic inverse of the Guardian field and is "
+        "maintained entirely by the ORM.",
+    )
+
+    @api.constrains(
+        "father_id", "mother_id", "guardian_id", "spouse_id", "children_ids"
+    )
+    def _check_family_self_reference(self):
+        for record in self:
+            for field_name, field_label in (
+                ("father_id", "Father"),
+                ("mother_id", "Mother"),
+                ("guardian_id", "Guardian"),
+                ("spouse_id", "Spouse"),
+            ):
+                related = record[field_name]
+                if related and related.id == record.id:
+                    error_message = """
+Context: Set %s
+Database ID: %s
+Problem: A contact cannot be set as its own %s
+Solution: Choose a different contact
+""" % (
+                        field_label,
+                        record.id,
+                        field_label.lower(),
+                    )
+                    raise ValidationError(_(error_message))
+
+            if record.id in record.children_ids.ids:
+                error_message = """
+Context: Set Children
+Database ID: %s
+Problem: A contact cannot be added to its own children
+Solution: Remove this contact from its own children list
+""" % (
+                    record.id,
+                )
+                raise ValidationError(_(error_message))
+
+    def _sync_parent_to_children(self, old_father, old_mother):
+        """Keep father_id/mother_id in sync with the parent's children_ids.
+
+        `self` is a single child record. `old_father`/`old_mother` are the
+        father_id/mother_id recordsets held by the record *before* the
+        current create()/write() was applied (empty recordsets on create).
+        Only father_id/mother_id feed children_ids - guardian_id is inverted
+        separately by the ward_ids One2many and must not be touched here.
+        """
+        self.ensure_one()
+        new_parents = self.father_id | self.mother_id
+        old_parents = (old_father | old_mother) - new_parents
+
+        for new_parent in new_parents:
+            if self.id not in new_parent.sudo().children_ids.ids:
+                new_parent.sudo().write({"children_ids": [(4, self.id)]})
+
+        for old_parent in old_parents:
+            old_parent.sudo().write({"children_ids": [(3, self.id)]})
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        empty = self.env["res.partner"]
+        for record, vals in zip(records, vals_list):
+            if "father_id" in vals or "mother_id" in vals:
+                record._sync_parent_to_children(empty, empty)
+        return records
+
+    def write(self, vals):
+        if "father_id" in vals or "mother_id" in vals:
+            previous_parents = {
+                record.id: (record.father_id, record.mother_id) for record in self
+            }
+            result = super().write(vals)
+            for record in self:
+                old_father, old_mother = previous_parents[record.id]
+                record._sync_parent_to_children(old_father, old_mother)
+            return result
+        return super().write(vals)
+
+    def link_child(self, child, relationship=False):
+        """Link `child` to `self` as father, mother, guardian, or plain child.
+
+        `self` is the parent/guardian (ensure_one) and `child` is a single
+        res.partner record (ensure_one). Fields that are already set on
+        `child` are never overwritten. Returns True.
+        """
+        self.ensure_one()
+        child.ensure_one()
+
+        if child == self:
+            error_message = """
+Context: Link Child
+Database ID: %s
+Problem: A contact cannot be linked as its own child
+Solution: Choose a different contact as child
+""" % (
+                self.id,
+            )
+            raise ValidationError(_(error_message))
+
+        if relationship == "father":
+            if not child.father_id:
+                child.write({"father_id": self.id})
+        elif relationship == "mother":
+            if not child.mother_id:
+                child.write({"mother_id": self.id})
+        elif relationship == "guardian":
+            if not child.guardian_id:
+                child.write({"guardian_id": self.id})
+
+        if relationship != "guardian":
+            if child.id not in self.children_ids.ids:
+                self.sudo().write({"children_ids": [(4, child.id)]})
+
+        return True
 
     def action_open_contact_address(self):
         for record in self.sudo():

--- a/ssi_partner/tests/__init__.py
+++ b/ssi_partner/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_ssi_partner  # noqa: F401
 from . import test_res_partner_family  # noqa: F401
+from . import test_res_partner_family_sync  # noqa: F401

--- a/ssi_partner/tests/test_data_res_partner_family_sync.yaml
+++ b/ssi_partner/tests/test_data_res_partner_family_sync.yaml
@@ -1,0 +1,529 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "Sync - Create Child With father_id Adds Child To Father's children_ids"
+    steps:
+      - step: "Create father"
+        action: "create"
+        model: "res.partner"
+        save_as: "a"
+        values:
+          name: "Sync Father A"
+          is_company: false
+
+      - step: "Create child with father_id set on create"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "Sync Child B"
+          is_company: false
+          father_id: "REC: a.id"
+
+      - step: "Assert father's children_ids contains the child"
+        action: "assert"
+        target: "a"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+  - name: "Sync - Write mother_id Adds Child To Mother's children_ids"
+    steps:
+      - step: "Create mother"
+        action: "create"
+        model: "res.partner"
+        save_as: "c"
+        values:
+          name: "Sync Mother C"
+          is_company: false
+
+      - step: "Create child without family fields"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "Sync Child B"
+          is_company: false
+
+      - step: "Write mother_id on the child"
+        action: "write"
+        target: "b"
+        values:
+          mother_id: "REC: c.id"
+
+      - step: "Assert mother's children_ids contains the child"
+        action: "assert"
+        target: "c"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+  - name: "Sync - Write guardian_id Populates ward_ids, Not children_ids"
+    steps:
+      - step: "Create guardian"
+        action: "create"
+        model: "res.partner"
+        save_as: "g"
+        values:
+          name: "Sync Guardian G"
+          is_company: false
+
+      - step: "Create child without family fields"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "Sync Child B"
+          is_company: false
+
+      - step: "Write guardian_id on the child"
+        action: "write"
+        target: "b"
+        values:
+          guardian_id: "REC: g.id"
+
+      - step: "Assert guardian's ward_ids contains the child"
+        action: "assert"
+        target: "g"
+        refresh: true
+        asserts:
+          ward_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+      - step: "Assert guardian's children_ids stays empty"
+        action: "assert"
+        target: "g"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+  - name: "Sync - Dual Role Father And Mother Keeps children_ids When One Role Cleared"
+    steps:
+      - step: "Create contact playing both parent roles"
+        action: "create"
+        model: "res.partner"
+        save_as: "a"
+        values:
+          name: "Sync Dual Role A"
+          is_company: false
+
+      - step: "Create child with father_id set to A"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "Sync Child B"
+          is_company: false
+          father_id: "REC: a.id"
+
+      - step: "Write mother_id on the child to the same contact A"
+        action: "write"
+        target: "b"
+        values:
+          mother_id: "REC: a.id"
+
+      - step: "Clear mother_id on the child"
+        action: "write"
+        target: "b"
+        values:
+          mother_id: false
+
+      - step: "Assert A's children_ids still contains the child (still father_id)"
+        action: "assert"
+        target: "a"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+  - name: "Sync - Changing father_id Moves Child Between Parents"
+    steps:
+      - step: "Create original father"
+        action: "create"
+        model: "res.partner"
+        save_as: "a"
+        values:
+          name: "Sync Original Father A"
+          is_company: false
+
+      - step: "Create new father"
+        action: "create"
+        model: "res.partner"
+        save_as: "d"
+        values:
+          name: "Sync New Father D"
+          is_company: false
+
+      - step: "Create child with father_id set to original father"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "Sync Child B"
+          is_company: false
+          father_id: "REC: a.id"
+
+      - step: "Change father_id to the new father"
+        action: "write"
+        target: "b"
+        values:
+          father_id: "REC: d.id"
+
+      - step: "Assert new father's children_ids contains the child"
+        action: "assert"
+        target: "d"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+      - step: "Assert original father's children_ids is now empty"
+        action: "assert"
+        target: "a"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+  - name: "Sync - Changing guardian_id Moves Ward Between Guardians"
+    steps:
+      - step: "Create original guardian"
+        action: "create"
+        model: "res.partner"
+        save_as: "g"
+        values:
+          name: "Sync Original Guardian G"
+          is_company: false
+
+      - step: "Create new guardian"
+        action: "create"
+        model: "res.partner"
+        save_as: "h"
+        values:
+          name: "Sync New Guardian H"
+          is_company: false
+
+      - step: "Create child with guardian_id set to original guardian"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "Sync Child B"
+          is_company: false
+          guardian_id: "REC: g.id"
+
+      - step: "Change guardian_id to the new guardian"
+        action: "write"
+        target: "b"
+        values:
+          guardian_id: "REC: h.id"
+
+      - step: "Assert new guardian's ward_ids contains the child"
+        action: "assert"
+        target: "h"
+        refresh: true
+        asserts:
+          ward_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+      - step: "Assert original guardian's ward_ids is now empty"
+        action: "assert"
+        target: "g"
+        refresh: true
+        asserts:
+          ward_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+  - name: "link_child - Father Relationship Sets father_id And children_ids When Empty"
+    steps:
+      - step: "Create parent A"
+        action: "create"
+        model: "res.partner"
+        save_as: "a"
+        values:
+          name: "LinkChild Parent A"
+          is_company: false
+
+      - step: "Create child B without father_id"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "LinkChild Child B"
+          is_company: false
+
+      - step: "Call link_child with relationship father"
+        action: "call"
+        target: "a"
+        method: "link_child"
+        args:
+          - "REC: b"
+        kwargs:
+          relationship: "father"
+
+      - step: "Assert child's father_id is now A"
+        action: "assert"
+        target: "b"
+        refresh: true
+        asserts:
+          father_id:
+            type: "m2o"
+            expected: "REC: a"
+
+      - step: "Assert A's children_ids contains the child"
+        action: "assert"
+        target: "a"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+  - name: "link_child - Father Relationship Does Not Overwrite Existing father_id"
+    steps:
+      - step: "Create actual father A"
+        action: "create"
+        model: "res.partner"
+        save_as: "a"
+        values:
+          name: "LinkChild Actual Father A"
+          is_company: false
+
+      - step: "Create another contact D"
+        action: "create"
+        model: "res.partner"
+        save_as: "d"
+        values:
+          name: "LinkChild Other Contact D"
+          is_company: false
+
+      - step: "Create child B with father_id already set to A"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "LinkChild Child B"
+          is_company: false
+          father_id: "REC: a.id"
+
+      - step: "Call link_child on D with relationship father"
+        action: "call"
+        target: "d"
+        method: "link_child"
+        args:
+          - "REC: b"
+        kwargs:
+          relationship: "father"
+
+      - step: "Assert child's father_id is still A"
+        action: "assert"
+        target: "b"
+        refresh: true
+        asserts:
+          father_id:
+            type: "m2o"
+            expected: "REC: a"
+
+      - step: "Assert D's children_ids contains the child"
+        action: "assert"
+        target: "d"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+  - name: "link_child - Guardian Relationship Sets guardian_id, Not children_ids"
+    steps:
+      - step: "Create guardian G"
+        action: "create"
+        model: "res.partner"
+        save_as: "g"
+        values:
+          name: "LinkChild Guardian G"
+          is_company: false
+
+      - step: "Create ward B"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "LinkChild Ward B"
+          is_company: false
+
+      - step: "Call link_child on G with relationship guardian"
+        action: "call"
+        target: "g"
+        method: "link_child"
+        args:
+          - "REC: b"
+        kwargs:
+          relationship: "guardian"
+
+      - step: "Assert ward's guardian_id is now G"
+        action: "assert"
+        target: "b"
+        refresh: true
+        asserts:
+          guardian_id:
+            type: "m2o"
+            expected: "REC: g"
+
+      - step: "Assert G's ward_ids contains the ward"
+        action: "assert"
+        target: "g"
+        refresh: true
+        asserts:
+          ward_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+      - step: "Assert G's children_ids stays empty"
+        action: "assert"
+        target: "g"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+  - name: "link_child - Without Relationship Only Links children_ids"
+    steps:
+      - step: "Create parent A"
+        action: "create"
+        model: "res.partner"
+        save_as: "a"
+        values:
+          name: "LinkChild No Relationship Parent A"
+          is_company: false
+
+      - step: "Create child B without any family field"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "LinkChild No Relationship Child B"
+          is_company: false
+
+      - step: "Call link_child on A without relationship"
+        action: "call"
+        target: "a"
+        method: "link_child"
+        args:
+          - "REC: b"
+
+      - step: "Assert A's children_ids contains the child"
+        action: "assert"
+        target: "a"
+        refresh: true
+        asserts:
+          children_ids:
+            type: "o2m"
+            check: "contains"
+            expected_records:
+              - "REC: b"
+
+      - step: "Assert child's father_id/mother_id/guardian_id stay falsy"
+        action: "assert"
+        target: "b"
+        refresh: true
+        asserts:
+          father_id:
+            type: "value"
+            operator: "is_falsy"
+          mother_id:
+            type: "value"
+            operator: "is_falsy"
+          guardian_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Sync - Self Reference On father_id Raises ValidationError"
+    steps:
+      - step: "Create contact B"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "Sync Self Reference B"
+          is_company: false
+
+      - step: "Write father_id on B to itself must be rejected"
+        action: "write"
+        target: "b"
+        expect_error:
+          type: "ValidationError"
+        values:
+          father_id: "REC: b.id"
+
+  - name: "Sync - Self Reference On guardian_id Raises ValidationError"
+    steps:
+      - step: "Create contact B"
+        action: "create"
+        model: "res.partner"
+        save_as: "b"
+        values:
+          name: "Sync Self Reference B"
+          is_company: false
+
+      - step: "Write guardian_id on B to itself must be rejected"
+        action: "write"
+        target: "b"
+        expect_error:
+          type: "ValidationError"
+        values:
+          guardian_id: "REC: b.id"
+
+  - name: "link_child - Linking Self As Child Raises ValidationError"
+    steps:
+      - step: "Create contact A"
+        action: "create"
+        model: "res.partner"
+        save_as: "a"
+        values:
+          name: "LinkChild Self Reference A"
+          is_company: false
+
+      - step: "Call link_child on A with A itself as child must be rejected"
+        action: "call"
+        target: "a"
+        method: "link_child"
+        args:
+          - "REC: a"
+        expect_error:
+          type: "ValidationError"

--- a/ssi_partner/tests/test_res_partner_family_sync.py
+++ b/ssi_partner/tests/test_res_partner_family_sync.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestResPartnerFamilySync(YamlTransactionCase):
+    def test_res_partner_family_sync(self):
+        self.run_yaml_scenario("test_data_res_partner_family_sync.yaml")

--- a/ssi_partner/views/res_partner_views.xml
+++ b/ssi_partner/views/res_partner_views.xml
@@ -153,6 +153,7 @@
                 <field name="guardian_id" />
                 <field name="spouse_id" />
                 <field name="children_ids" widget="many2many_tags" />
+                <field name="ward_ids" widget="many2many_tags" />
             </group>
         </xpath>
     </field>


### PR DESCRIPTION
## Ringkasan

- Tambah field `ward_ids` (One2many, inverse `guardian_id`) pada `res.partner`, dipelihara ORM tanpa kode sinkronisasi, ditampilkan di grup Family form kontak berdampingan dengan `children_ids`.
- Tambah helper privat `_sync_parent_to_children()` + override `create()`/`write()`: menulis `father_id`/`mother_id` selalu menyinkronkan `children_ids` sisi orang tua dua arah. `guardian_id` **tidak** ikut ke `children_ids` — wali bukan orang tua, sisi wali cukup lewat `ward_ids`.
- Tambah method publik `link_child(self, child, relationship=False)` sebagai kontrak lintas modul untuk menautkan anak ke orang tua/wali tanpa menimpa field yang sudah terisi.
- Tambah `@api.constrains` anti self-reference untuk `father_id`/`mother_id`/`guardian_id`/`spouse_id`/`children_ids`.
- Tambah unit test `odoo-yaml-test` (10 skenario positif + 3 negatif) mencakup seluruh Kriteria Penerimaan & Skenario Uji di issue.

Closes #62

## Test plan

- [x] Unit test YAML ditulis, dijalankan di CI GitHub
- [ ] CI hijau (menunggu hasil `gh pr checks`)