### PR TITLE
[UPD] ssi_partner: Tambahkan field nickname pada res.partner

### DIFF
--- a/ssi_partner/models/res_partner.py
+++ b/ssi_partner/models/res_partner.py
@@ -7,8 +7,22 @@ from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
+    """Extend ``res.partner`` with SSI personal, company, and family data.
+
+    Adds identity fields (nickname, blood type, religion, ethnicity,
+    marital status), family relations (father, mother, guardian,
+    spouse, children, wards), and company classification fields
+    (ownership type, entity type) used across SSI modules.
+    """
+
     _inherit = "res.partner"
 
+    nickname = fields.Char(
+        string="Nickname",
+        required=False,
+        help="Familiar or informal name the individual contact is "
+        "commonly called by, as opposed to their official name.",
+    )
     type = fields.Selection(
         selection_add=[
             ("branch", "Branch Address"),

--- a/ssi_partner/tests/test_data_ssi_partner.yaml
+++ b/ssi_partner/tests/test_data_ssi_partner.yaml
@@ -143,3 +143,68 @@ scenarios:
             - "EVAL: registry['usage'].id"
         save_as: "result"
         expect_count: 1
+
+  - name: "Partner - Nickname is Stored on Create"
+    steps:
+      - step: "Create individual partner with nickname"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner_nickname"
+        values:
+          name: "Test Nickname Partner"
+          is_company: false
+          nickname: "Nick"
+
+      - step: "Assert nickname stored as given"
+        action: "assert"
+        target: "partner_nickname"
+        asserts:
+          nickname:
+            type: "value"
+            expected: "Nick"
+
+  - name: "Partner - Nickname can be Updated via Write"
+    steps:
+      - step: "Create individual partner with nickname"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner_nickname_write"
+        values:
+          name: "Test Nickname Write Partner"
+          is_company: false
+          nickname: "Old Nick"
+
+      - step: "Write new nickname"
+        action: "write"
+        target: "partner_nickname_write"
+        values:
+          nickname: "New Nick"
+
+      - step: "Assert nickname changed to new value"
+        action: "assert"
+        target: "partner_nickname_write"
+        asserts:
+          nickname:
+            type: "value"
+            expected: "New Nick"
+
+  - name: "Partner - Nickname is Optional"
+    steps:
+      - step: "Create individual partner without nickname"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner_no_nickname"
+        values:
+          name: "Test No Nickname Partner"
+          is_company: false
+
+      - step: "Assert partner created successfully without nickname"
+        action: "assert"
+        target: "partner_no_nickname"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          nickname:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_partner/views/res_partner_views.xml
+++ b/ssi_partner/views/res_partner_views.xml
@@ -126,6 +126,7 @@
     <field name="priority" eval="20" />
     <field name="arch" type="xml">
         <xpath expr="//group[@name='personal_information_group']" position="inside">
+            <field name="nickname" />
             <field name="nationality_id" string="Nationality (Country)" />
             <field name="gender" />
             <field name="birthdate_date" string="Date of Birth" />


### PR DESCRIPTION
## Ringkasan

* Tambah field `nickname` (Char, opsional) pada `res.partner` untuk menyimpan nama panggilan kontak individu secara terstruktur.
* Tampilkan `nickname` sebagai entri pertama di group Personal Information pada form kontak, sebelum `nationality_id`.
* Tambah skenario uji create/write/optional untuk `nickname` di `tests/test_data_ssi_partner.yaml`.

Closes #64