### PR TITLE
[UPD] ssi_partner_language

### DIFF
--- a/ssi_partner_language/README.rst
+++ b/ssi_partner_language/README.rst
@@ -7,6 +7,12 @@ Partner Language
 ================
 
 
+Work Instruction
+================
+
+* `Contact <docs/res_partner/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_partner_language/__manifest__.py
+++ b/ssi_partner_language/__manifest__.py
@@ -12,10 +12,12 @@
     "application": True,
     "depends": [
         "ssi_partner",
+        "web_tour",
     ],
     "data": [
         "security/ir.model.access.csv",
         "views/res_partner_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
     "contributors": [

--- a/ssi_partner_language/docs/res_partner/01-create.md
+++ b/ssi_partner_language/docs/res_partner/01-create.md
@@ -1,0 +1,24 @@
+# Create Contact
+
+> **Module:** ssi_partner_language\
+> **Extends:** ssi_partner — model `res.partner`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the Contacts form gains a **Languages** page (individual
+contacts only, i.e. **Individual** is selected instead of **Company**):
+
+- **Languages**: a list of languages the contact can use, with a proficiency rating for
+  each. Optional — zero or more rows may be added. Each row has:
+  - **Language**: the language, selected from the standard list of installed languages.
+    Required per row.
+  - **Reading**, **Writing**, **Speaking**, **Listening**: proficiency rating for that
+    skill, one of `0` (No Proficiency) through `5` (Functionally Native Proficiency),
+    with `+` half-steps in between. Each defaults to `0`. Required per row.
+  - **Description**: free-text optional note for the row. Only shown when a row is
+    opened in its own pop-up form, not in the inline table.
+
+## Modified Validation
+
+- Saving fails with an error if the same **Language** is added twice for the same
+  contact.

--- a/ssi_partner_language/models/__init__.py
+++ b/ssi_partner_language/models/__init__.py
@@ -3,6 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (
-    partner_languange,
+    partner_language,
     res_partner,
 )

--- a/ssi_partner_language/models/partner_language.py
+++ b/ssi_partner_language/models/partner_language.py
@@ -20,7 +20,15 @@ LANGUAGE_RATING = [
 ]
 
 
-class PartnerLanguange(models.Model):
+class PartnerLanguage(models.Model):
+    """
+    Records a single language proficiency entry for a contact.
+    Each record links one ``res.partner`` to one language, with
+    separate proficiency ratings for reading, writing, speaking, and
+    listening. Rows are managed inline from the Contacts form and have
+    no standalone menu of their own.
+    """
+
     _name = "partner.language"
     _description = "Partner Language"
 
@@ -72,6 +80,14 @@ class PartnerLanguange(models.Model):
         "name",
     )
     def _check_no_duplicate_language(self):
+        """Forbid a partner from having the same language twice.
+
+        Raised as a ``UserError`` when another ``partner.language``
+        record already exists for the same ``partner_id`` and
+        ``name`` combination.
+
+        :raises UserError: when a duplicate language entry is found
+        """
         obj_language = self.env["partner.language"]
         for language in self:
             criteria = [

--- a/ssi_partner_language/models/res_partner.py
+++ b/ssi_partner_language/models/res_partner.py
@@ -6,6 +6,13 @@ from odoo import fields, models
 
 
 class ResPartner(models.Model):
+    """
+    Adds language proficiency tracking to contacts.
+    Lets a contact list one or more spoken/written languages, each
+    rated for reading, writing, speaking, and listening proficiency,
+    via the ``partner.language`` one2many.
+    """
+
     _inherit = "res.partner"
 
     language_ids = fields.One2many(

--- a/ssi_partner_language/static/tests/tours/res_partner_tour.js
+++ b/ssi_partner_language/static/tests/tours/res_partner_tour.js
@@ -1,0 +1,90 @@
+// Copyright 2025 OpenSynergy Indonesia
+// Copyright 2025 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_language.res_partner_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/res_partner/01-create.md (E1 delta -- Additional Fields)
+    //
+    // Base Flow (ssi_partner, docs/res_partner/01-create.md) has no
+    // navigation steps of its own to reuse -- it documents fields only, and
+    // there is no base Instruction Kerja for res.partner. So this tour
+    // writes the standard Contacts navigation itself: open the Contacts
+    // app, click Create, then assert the Languages tab this module adds.
+    tour.register(
+        "ssi_partner_language_res_partner_field_languages",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Open the Contacts app. The Contacts app tile has no
+            // action of its own; it redirects straight to the Contacts
+            // action (its only actionable child menu), so there is no
+            // intermediate landing view to race against.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                // Gate: wait for the Contacts action to actually be
+                // mounted. The Contacts action's view_mode starts with
+                // "kanban", so the landing view is Kanban, not List.
+                content: "Contacts kanban view is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contacts)",
+                extra_trigger: ".o_kanban_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Click Create. The Contacts kanban view's Create button
+            // uses the kanban-specific class, not the list one.
+            {
+                content: "Click Create",
+                trigger: ".o-kanban-button-new",
+                extra_trigger: ".o_kanban_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── The Contacts action defaults new records to Company
+            // (context default_is_company: True), and the Languages page
+            // this module adds is invisible while is_company is True.
+            // Switch to Individual first so the assertion below is
+            // checking real conditional visibility, not a tab that is
+            // simply always shown.
+            {
+                content: "Switch Contact Type to Individual",
+                trigger:
+                    ".o_field_widget[name='company_type'] input[data-value='person']",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+
+            // ── Additional Fields (docs/res_partner/01-create.md, delta of
+            // ssi_partner_language) -- the Languages page becomes visible.
+            // Delta-only tour: it stops here, it does not fill any field
+            // and does not continue to Save (E1 delta-only; the Modified
+            // Validation part of the IK is not covered by a tour, see
+            // odoo-development-ui-test scope-and-boundaries.md).
+            {
+                content: "Languages tab is displayed",
+                trigger:
+                    ".o_notebook_headers li.nav-item:not(.o_invisible_modifier)" +
+                    " > a.nav-link:contains(Languages)",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_partner_language/tests/__init__.py
+++ b/ssi_partner_language/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_partner_language  # noqa: F401
+from . import test_ui_res_partner  # noqa: F401

--- a/ssi_partner_language/tests/test_partner_language.py
+++ b/ssi_partner_language/tests/test_partner_language.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestPartnerLanguage(YamlTransactionCase):
+    """Cover ``partner.language`` create and duplicate-check behavior."""
+
     def test_partner_language(self):
+        """Run the create scenario for ``partner.language``."""
         self.run_yaml_scenario("test_data_partner_language.yaml")

--- a/ssi_partner_language/tests/test_ui_res_partner.py
+++ b/ssi_partner_language/tests/test_ui_res_partner.py
@@ -1,0 +1,21 @@
+# Copyright 2025 OpenSynergy Indonesia
+# Copyright 2025 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiResPartner(HttpSavepointCase):
+    """Tour test for the ``res.partner`` Languages field delta."""
+
+    def test_field_languages(self):
+        """Run the delta tour for the Contacts create form.
+
+        IK: docs/res_partner/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_language_res_partner_field_languages",
+            login="admin",
+        )

--- a/ssi_partner_language/views/assets.xml
+++ b/ssi_partner_language/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 OpenSynergy Indonesia
+     Copyright 2025 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_partner_language assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_partner_language/static/tests/tours/res_partner_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/ssi_partner_language/views/res_partner_views.xml
+++ b/ssi_partner_language/views/res_partner_views.xml
@@ -19,6 +19,16 @@
                             <field name="speak_rating" />
                             <field name="listen_rating" />
                         </tree>
+                        <form>
+                            <group name="partner_language_1" colspan="4" col="2">
+                                <field name="name" />
+                                <field name="description" />
+                                <field name="read_rating" />
+                                <field name="write_rating" />
+                                <field name="speak_rating" />
+                                <field name="listen_rating" />
+                            </group>
+                        </form>
                     </field>
                 </page>
             </xpath>


### PR DESCRIPTION
## Ringkasan

Menuntaskan seluruh temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-partner`
pada modul `ssi_partner_language` (validator `module`, `ik`, `unit-test`), tanpa mengubah
perilaku fungsional apa pun yang sudah berjalan.

* Perbaiki nama berkas & class model `partner.language`: `models/partner_languange.py`
  menjadi `models/partner_language.py`, class `PartnerLanguange` menjadi
  `PartnerLanguage`. Nama model `partner.language` **tidak berubah**.
* Tambah docstring pada seluruh class & method yang belum punya, termasuk berkas
  `tests/`.
* Tambah inline `<form>` untuk field one2many `language_ids` di form Contacts
  (sebelumnya hanya punya inline `<tree>`).
* Tambah Instruksi Kerja (IK) delta `docs/res_partner/01-create.md` mendokumentasikan
  field **Languages** yang ditambahkan modul ini pada `res.partner`.
* Tambah tour UI test delta `res_partner_tour.js` beserta `tests/test_ui_res_partner.py`
  yang memverifikasi tab **Languages** tampil saat kontak diset sebagai **Individual**.

## Verifikasi

* `verify-module.sh` — `error=0 warn=0 defer=0`
* `validate-ik.sh` — `error=0 warn=0 defer=0`
* `validate-tour.sh` — `error=0 warn=0 defer=0`
* `validate-unit-test.sh` — `error=0 warn=1` (peringatan `setiap-api-constrains-diuji-dengan-expect-error`
  dinyatakan **di luar lingkup** issue #68)
* `pre-commit-gate.sh` — `GATE OK`, 0 pelanggaran baru

Closes #68