### PR TITLE
[UPD] ssi_partner_portal - penuhi validator kepatuhan

### DIFF
--- a/ssi_partner_portal/.validator-exceptions
+++ b/ssi_partner_portal/.validator-exceptions
@@ -1,0 +1,8 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+#
+# Format: <validator> <kunci-temuan> -- <alasan>
+# Lihat skill odoo-development, references/validator-contract.md §13.
+
+ik modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali|docs/ -- Modul ini murni permukaan portal/website: satu-satunya cara pengguna mengoperasikan model portal_partner_bank_account adalah controller @http.route (/my/bank_accounts, /my/bank_account) yang me-render template QWeb frontend; tidak ada ir.actions.act_window/menuitem/form view backend sama sekali (tak ada menu.xml di modul ini). Ini arketipe E7 pada skill odoo-development-instruksi-kerja (references/modul-extension.md) dan skill odoo-development-ui-test (references/scope-and-boundaries.md): IK dan tour untuk permukaan portal/website dinyatakan eksplisit di luar cakupan kedua skill tersebut, jadi direktori docs/ dengan format IK backend tidak dapat dibuat untuk model ini.

--- a/ssi_partner_portal/controllers/portal.py
+++ b/ssi_partner_portal/controllers/portal.py
@@ -21,10 +21,22 @@ CustomerPortal.OPTIONAL_BILLING_FIELDS += [
 
 
 class CustomerPortalExtended(CustomerPortal):
+    """
+    Extends the portal controller with bank account self-service pages
+    and additional profile fields (mobile, gender, birth data, avatar)
+    on the ``/my/account`` form.
+    """
+
     @route(
         ["/my/bank_accounts"], type="http", auth="user", website=True, methods=["GET"]
     )
     def bank_accounts(self):
+        """Render the list of bank accounts of the logged in partner.
+
+        :return: rendered ``ssi_partner_portal.portal_my_bank_accounts``
+            page listing the ``portal_partner_bank_account`` records
+            owned by the current user's partner
+        """
         values = self._prepare_portal_layout_values()
         values["get_error"] = portal.get_error
         values["bank_account_ids"] = request.env["portal_partner_bank_account"].search(
@@ -45,6 +57,17 @@ class CustomerPortalExtended(CustomerPortal):
         methods=["GET", "POST"],
     )
     def bank_account(self, **post):
+        """Show, create, or update a single portal bank account.
+
+        On ``GET`` it renders the form (empty for a new record, or
+        pre-filled when ``id`` is given). On ``POST`` it validates
+        the submitted ``bank``/``currency`` references, then creates
+        or writes the ``portal_partner_bank_account`` record and
+        redirects back to the bank account list.
+
+        :return: rendered ``ssi_partner_portal.portal_my_bank_account``
+            page, or a redirect to ``/my/bank_accounts`` on success
+        """
         id = post.get("id")
         bank_account_obj = request.env["portal_partner_bank_account"]
         bank_obj = request.env["res.bank"].sudo()
@@ -124,6 +147,10 @@ class CustomerPortalExtended(CustomerPortal):
         methods=["GET", "POST"],
     )
     def remove_bank_account(self, **post):
+        """Delete a portal bank account belonging to the current user.
+
+        :return: redirect to ``/my/bank_accounts``
+        """
         id = post.get("id")
         bank_account_id = request.env["portal_partner_bank_account"].search(
             [("id", "=", int(id))]
@@ -132,10 +159,27 @@ class CustomerPortalExtended(CustomerPortal):
         return request.redirect("/my/bank_accounts")
 
     def convert_url_to_base64(self, url):
+        """Fetch a remote image and return it base64-encoded.
+
+        Used when the avatar submitted from ``/my/account`` is posted
+        as an external URL instead of an inline ``data:`` URI.
+
+        :param url: HTTP(S) URL of the image to download
+        :return: base64-encoded bytes of the downloaded image
+        """
         return base64.b64encode(requests.get(url, timeout=30).content)
 
     @route(["/my/account"], type="http", auth="user", website=True)
     def account(self, redirect=None, **post):
+        """Extend the account form to accept an avatar upload.
+
+        Overridden so ``image_1920`` posted either as a ``data:`` URI
+        or as a plain external URL (converted via
+        ``convert_url_to_base64``) is normalized to raw base64 before
+        being handed to the original ``account`` implementation.
+
+        :return: same as the overridden ``CustomerPortal.account``
+        """
         if "input_image_1920" in post:
             post.pop("input_image_1920")
             if post.get("image_1920"):

--- a/ssi_partner_portal/models/portal_partner_bank_account.py
+++ b/ssi_partner_portal/models/portal_partner_bank_account.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class PortalPartnerBankAccount(models.Model):
+    """
+    Portal-facing view of ``res.partner.bank`` used by the bank
+    account self-service pages under ``/my/bank_accounts``.
+    Shares the same database table as ``res.partner.bank`` so portal
+    users manage the same records exposed in the backend, scoped to
+    their own partner through the security rules of this module.
+    """
+
     _name = "portal_partner_bank_account"
     _inherit = ["res.partner.bank"]
     _description = "Portal Partner Bank Account"

--- a/ssi_partner_portal/tests/__init__.py
+++ b/ssi_partner_portal/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_portal_partner_bank_account  # noqa: F401

--- a/ssi_partner_portal/tests/test_data_portal_partner_bank_account.yaml
+++ b/ssi_partner_portal/tests/test_data_portal_partner_bank_account.yaml
@@ -1,0 +1,71 @@
+scenarios:
+  - name: "Create Portal Partner Bank Account"
+    steps:
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner"
+        values:
+          name: "Test Portal Bank Account Owner"
+          is_company: true
+
+      - step: "Create portal bank account"
+        action: "create"
+        model: "portal_partner_bank_account"
+        save_as: "bank_account"
+        values:
+          partner_id: "REC: owner.id"
+          acc_number: "ID 1234 5678"
+          acc_holder_name: "Test Portal Bank Account Owner"
+
+      - step: "Assert record saved with computed sanitized number"
+        action: "assert"
+        target: "bank_account"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          partner_id:
+            type: "m2o"
+            expected: "REC: owner"
+          acc_number:
+            type: "value"
+            expected: "ID 1234 5678"
+          sanitized_acc_number:
+            type: "value"
+            expected: "ID12345678"
+
+  - name: "Update Account Number Refreshes Sanitized Number"
+    steps:
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner"
+        values:
+          name: "Test Portal Bank Account Owner 2"
+          is_company: true
+
+      - step: "Create portal bank account"
+        action: "create"
+        model: "portal_partner_bank_account"
+        save_as: "bank_account"
+        values:
+          partner_id: "REC: owner.id"
+          acc_number: "ID-0001"
+
+      - step: "Update account number"
+        action: "write"
+        target: "bank_account"
+        values:
+          acc_number: "ID-0002"
+
+      - step: "Assert sanitized number follows the new account number"
+        action: "assert"
+        target: "bank_account"
+        asserts:
+          acc_number:
+            type: "value"
+            expected: "ID-0002"
+          sanitized_acc_number:
+            type: "value"
+            expected: "ID0002"

--- a/ssi_partner_portal/tests/test_portal_partner_bank_account.py
+++ b/ssi_partner_portal/tests/test_portal_partner_bank_account.py
@@ -1,0 +1,44 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+from psycopg2 import IntegrityError
+
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestPortalPartnerBankAccount(YamlTransactionCase):
+    """Scenario tests for ``portal_partner_bank_account``."""
+
+    def test_portal_partner_bank_account(self):
+        """Run the CRUD and compute scenario for the model."""
+        self.run_yaml_scenario("test_data_portal_partner_bank_account.yaml")
+
+    @mute_logger("odoo.sql_db")
+    def test_acc_number_required(self):
+        """Reject a record created without the required ``acc_number``.
+
+        Pure Python — trigger P5 (L-22: ``psycopg2.IntegrityError`` is
+        outside the 12 error types ``expect_error`` understands, since
+        ``acc_number`` is only enforced by the NOT NULL column
+        constraint inherited from ``res.partner.bank``, not by a
+        Python-level ``@api.constrains``).
+        ``mute_logger("odoo.sql_db")`` silences the PostgreSQL ERROR
+        line this deliberately triggers, so ``oca_checklog_odoo``
+        does not fail the CI even though the test itself passes.
+        """
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Test Missing Account Number Owner",
+                "is_company": True,
+            }
+        )
+        with self.assertRaises(IntegrityError):
+            self.env["portal_partner_bank_account"].create(
+                {
+                    "partner_id": partner.id,
+                }
+            )

--- a/ssi_partner_portal/views/assets.xml
+++ b/ssi_partner_portal/views/assets.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template
         id="assets_frontend"
-        inherit_id="web_editor.assets_frontend"
+        inherit_id="web.assets_frontend"
         name="Portal Assets"
         priority="15"
     >

--- a/ssi_partner_portal/views/portal_templates.xml
+++ b/ssi_partner_portal/views/portal_templates.xml
@@ -228,7 +228,7 @@
                                 type="text"
                                 t-attf-class="form-control form-control-sm"
                                 name="acc_number"
-                                required="required"
+                                required="1"
                                 t-att-value="current_bank_account_id.acc_number"
                             />
                         </div>


### PR DESCRIPTION
## Ringkasan

Menuntaskan seluruh temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-partner`
pada modul `ssi_partner_portal` (validator `module`, `ik`, `unit-test`, `web`), tanpa
mengubah perilaku fungsional yang sudah berjalan.

- Tambah docstring bahasa Inggris (gaya reST) pada seluruh class & method yang sebelumnya
  belum berdocstring: controller `CustomerPortalExtended` (`account`, `bank_account`,
  `bank_accounts`, `convert_url_to_base64`, `remove_bank_account`), dan model
  `PortalPartnerBankAccount`.
- Ganti `required="required"` (bukan sintaks Odoo 14 yang sah) menjadi `required="1"` pada
  field Account Number di form portal bank account — field ini memang selalu wajib, jadi
  perilakunya tidak berubah.
- Daftarkan aset frontend lewat `inherit_id="web.assets_frontend"` (sebelumnya
  `web_editor.assets_frontend`, tidak terdeteksi sebagai pendaftaran aset yang sah) sesuai
  konvensi seri 14.0.
- Tambah direktori `tests/` (modul ini sebelumnya tidak punya test sama sekali): skenario
  CRUD + compute (`odoo-yaml-test`) untuk `portal_partner_bank_account`, plus satu test
  Python murni untuk constraint `NOT NULL` pada `acc_number` (kode pemicu `P5`,
  keterbatasan `L-22` — `psycopg2.IntegrityError` di luar 12 tipe yang dipahami
  `expect_error`).

## Catatan penyimpangan dari Rencana Eksekusi issue

Issue #69 meminta IK (`docs/<model>/`) + tour untuk model `portal_partner_bank_account`.
Setelah diperiksa, modul ini **murni permukaan portal/website**: satu-satunya cara
pengguna mengoperasikan model ini adalah controller `@http.route` (`/my/bank_accounts`,
`/my/bank_account`) yang me-render template QWeb frontend — tidak ada
`ir.actions.act_window`/`menuitem`/form view backend sama sekali (modul ini tidak punya
`menu.xml`). Ini persis arketipe **E7** pada skill `odoo-development-instruksi-kerja`
(`references/modul-extension.md`) dan `odoo-development-ui-test`
(`references/scope-and-boundaries.md`): IK & tour untuk permukaan portal/website
dinyatakan eksplisit **di luar cakupan** kedua skill tersebut.

Karena itu direktori `docs/` tidak dibuat; sebagai gantinya ditambahkan
`.validator-exceptions` (kontrak validator §13) untuk temuan
`ik modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali|docs/`, dengan alasan di atas
tertulis lengkap di berkasnya. `validate-ik.sh` mencetak `error=0 excepted=1 status=OK`.

## Verifikasi

```
#VALIDATOR name=module    target=ssi_partner_portal series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=web       target=ssi_partner_portal series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_partner_portal series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_partner_portal series=14.0 error=0 warn=0 defer=0 excepted=1 status=OK
#VALIDATOR name=tour      target=ssi_partner_portal series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-partner modules=1 failed=0 skipped=0 status=OK
```

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)