### PR TITLE
[UPD] ssi_partner_experience_portal - penuhi validator kepatuhan

### DIFF
--- a/ssi_partner_experience_portal/.validator-exceptions
+++ b/ssi_partner_experience_portal/.validator-exceptions
@@ -1,0 +1,8 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+#
+# Format: <validator> <kunci-temuan> -- <alasan>
+# Lihat skill odoo-development, references/validator-contract.md §13.
+
+ik modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali|docs/ -- Modul ini murni permukaan portal/website: satu-satunya cara pengguna mengoperasikan model portal_partner_academic dan portal_partner_experience adalah controller @http.route (/my/academics, /my/academic, /my/experiences, /my/experience) yang me-render template QWeb frontend; tidak ada ir.actions.act_window/menuitem/form view backend sama sekali (tak ada menu.xml di modul ini, satu-satunya <form> di views/portal_templates.xml adalah HTML form portal biasa, bukan ir.ui.view Odoo). Ini arketipe E7 pada skill odoo-development-instruksi-kerja (references/modul-extension.md) dan skill odoo-development-ui-test (references/scope-and-boundaries.md): IK dan tour untuk permukaan portal/website dinyatakan eksplisit di luar cakupan kedua skill tersebut, jadi direktori docs/ dengan format IK backend tidak dapat dibuat untuk model-model ini.

--- a/ssi_partner_experience_portal/controllers/portal.py
+++ b/ssi_partner_experience_portal/controllers/portal.py
@@ -13,8 +13,22 @@ _logger = logging.getLogger(__name__)
 
 
 class CustomerPortalExtended(CustomerPortal):
+    """Portal routes for a partner's academic and professional history.
+
+    Extends the core ``CustomerPortal`` controller with list/edit/
+    remove routes for ``portal_partner_academic`` and
+    ``portal_partner_experience``, mirroring the ``/my/*`` pattern
+    already used by other portal document types.
+    """
+
     @route(["/my/academics"], type="http", auth="user", website=True, methods=["GET"])
     def academics(self):
+        """Render the list of the current user's academic experiences.
+
+        :return: rendered ``portal_my_academics`` page listing every
+            ``portal_partner_academic`` record owned by the logged-in
+            user's partner
+        """
         values = self._prepare_portal_layout_values()
         values["get_error"] = portal.get_error
         values["academic_ids"] = request.env["portal_partner_academic"].search(
@@ -35,6 +49,22 @@ class CustomerPortalExtended(CustomerPortal):
         methods=["GET", "POST"],
     )
     def academic(self, **post):
+        """Show or save one academic experience record for the portal.
+
+        On ``GET`` renders the create/edit form (empty when ``id`` is
+        absent, pre-filled when present). On ``POST`` validates the
+        submitted values, creates or writes the
+        ``portal_partner_academic`` record for the current user's
+        partner, then redirects to ``/my/academics``; on validation
+        failure the form is re-rendered with ``error_message`` set.
+
+        :param post: form payload (``id``, ``location``,
+            ``date_start``, ``expire``, ``date_end``, ``diploma``,
+            ``gpa``, ``activities``, ``note``,
+            ``partner_address``, ``education_level``,
+            ``field_of_study``)
+        :return: rendered form page, or a redirect on success
+        """
         id = post.get("id")
         partner_obj = request.env["res.partner"].sudo()
         academic_obj = request.env["portal_partner_academic"]
@@ -133,6 +163,13 @@ class CustomerPortalExtended(CustomerPortal):
         methods=["GET", "POST"],
     )
     def remove_academic(self, **post):
+        """Delete one academic experience record, then go back to list.
+
+        :param post: route payload; ``id`` is the ``portal_
+            partner_academic`` record to delete (also available as
+            the ``id`` path segment)
+        :return: redirect to ``/my/academics``
+        """
         id = post.get("id")
         academic_id = request.env["portal_partner_academic"].search(
             [("id", "=", int(id))]
@@ -142,6 +179,12 @@ class CustomerPortalExtended(CustomerPortal):
 
     @route(["/my/experiences"], type="http", auth="user", website=True, methods=["GET"])
     def experiences(self):
+        """Render the list of the current user's professional history.
+
+        :return: rendered ``portal_my_experiences`` page listing every
+            ``portal_partner_experience`` record owned by the
+            logged-in user's partner
+        """
         values = self._prepare_portal_layout_values()
         values["get_error"] = portal.get_error
         values["experience_ids"] = request.env["portal_partner_experience"].search(
@@ -162,6 +205,20 @@ class CustomerPortalExtended(CustomerPortal):
         methods=["GET", "POST"],
     )
     def experience(self, **post):
+        """Show or save one professional experience record.
+
+        On ``GET`` renders the create/edit form (empty when ``id`` is
+        absent, pre-filled when present). On ``POST`` validates the
+        submitted values, creates or writes the
+        ``portal_partner_experience`` record for the current user's
+        partner, then redirects to ``/my/experiences``; on validation
+        failure the form is re-rendered with ``error_message`` set.
+
+        :param post: form payload (``id``, ``job_position``,
+            ``job_level``, ``location``, ``date_start``, ``expire``,
+            ``date_end``, ``note``, ``partner_address``)
+        :return: rendered form page, or a redirect on success
+        """
         id = post.get("id")
         partner_obj = request.env["res.partner"].sudo()
         experience_obj = request.env["portal_partner_experience"]
@@ -233,6 +290,13 @@ class CustomerPortalExtended(CustomerPortal):
         methods=["GET", "POST"],
     )
     def remove_experience(self, **post):
+        """Delete one professional experience record, then go to list.
+
+        :param post: route payload; ``id`` is the ``portal_
+            partner_experience`` record to delete (also available as
+            the ``id`` path segment)
+        :return: redirect to ``/my/experiences``
+        """
         id = post.get("id")
         experience_id = request.env["portal_partner_experience"].search(
             [("id", "=", int(id))]

--- a/ssi_partner_experience_portal/models/portal_partner_academic.py
+++ b/ssi_partner_experience_portal/models/portal_partner_academic.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class PortalPartnerAcademic(models.Model):
+    """Expose ``partner.academic`` records to the customer portal.
+
+    Same PostgreSQL table as ``partner.academic`` (``_table =
+    "partner_academic"``), so no data is duplicated. This model only
+    exists so portal-specific access rights (``ir.model.access.csv``,
+    ``ir.rule``) can be attached without loosening the backend model.
+    """
+
     _name = "portal_partner_academic"
     _inherit = ["partner.academic"]
     _description = "Portal Partner Academic"

--- a/ssi_partner_experience_portal/models/portal_partner_experience.py
+++ b/ssi_partner_experience_portal/models/portal_partner_experience.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class PortalPartnerExperience(models.Model):
+    """Expose ``partner.experience`` records to the customer portal.
+
+    Same PostgreSQL table as ``partner.experience`` (``_table =
+    "partner_experience"``), so no data is duplicated. This model only
+    exists so portal-specific access rights (``ir.model.access.csv``,
+    ``ir.rule``) can be attached without loosening the backend model.
+    """
+
     _name = "portal_partner_experience"
     _inherit = ["partner.experience"]
     _description = "Portal Partner Experience"

--- a/ssi_partner_experience_portal/tests/__init__.py
+++ b/ssi_partner_experience_portal/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_portal_partner_academic  # noqa: F401
+from . import test_portal_partner_experience  # noqa: F401

--- a/ssi_partner_experience_portal/tests/test_data_portal_partner_academic.yaml
+++ b/ssi_partner_experience_portal/tests/test_data_portal_partner_academic.yaml
@@ -1,0 +1,102 @@
+scenarios:
+  - name: "Create Portal Partner Academic"
+    steps:
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner"
+        values:
+          name: "Test Portal Academic Owner"
+          is_company: false
+
+      - step: "Create academic institution"
+        action: "create"
+        model: "res.partner"
+        save_as: "institution"
+        values:
+          name: "Test Portal Academic Institution"
+          is_company: true
+
+      - step: "Create portal academic record"
+        action: "create"
+        model: "portal_partner_academic"
+        save_as: "academic"
+        values:
+          partner_id: "REC: owner.id"
+          partner_address_id: "REC: institution.id"
+          date_start: 2020-01-01
+          diploma: "12345"
+
+      - step: "Assert record saved with the submitted values"
+        action: "assert"
+        target: "academic"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          partner_id:
+            type: "m2o"
+            expected: "REC: owner"
+          partner_address_id:
+            type: "m2o"
+            expected: "REC: institution"
+          date_start:
+            type: "value"
+            expected: 2020-01-01
+          diploma:
+            type: "value"
+            expected: "12345"
+
+  - name: "Update Location Persists the New Value"
+    steps:
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner2"
+        values:
+          name: "Test Portal Academic Owner 2"
+          is_company: false
+
+      - step: "Create portal academic record"
+        action: "create"
+        model: "portal_partner_academic"
+        save_as: "academic2"
+        values:
+          partner_id: "REC: owner2.id"
+          date_start: 2019-06-01
+          location: "Jakarta"
+
+      - step: "Update location"
+        action: "write"
+        target: "academic2"
+        values:
+          location: "Bandung"
+
+      - step: "Assert location reflects the update"
+        action: "assert"
+        target: "academic2"
+        asserts:
+          location:
+            type: "value"
+            expected: "Bandung"
+
+  - name: "Date End Before Date Start Is Rejected"
+    steps:
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner3"
+        values:
+          name: "Test Portal Academic Owner 3"
+          is_company: false
+
+      - step: "Create record with date_end before date_start"
+        action: "create"
+        model: "portal_partner_academic"
+        expect_error:
+          type: "UserError"
+          message_contains: "Date end must be greater than date start"
+        values:
+          partner_id: "REC: owner3.id"
+          date_start: 2022-01-01
+          date_end: 2021-01-01

--- a/ssi_partner_experience_portal/tests/test_data_portal_partner_experience.yaml
+++ b/ssi_partner_experience_portal/tests/test_data_portal_partner_experience.yaml
@@ -1,0 +1,102 @@
+scenarios:
+  - name: "Create Portal Partner Experience"
+    steps:
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner"
+        values:
+          name: "Test Portal Experience Owner"
+          is_company: false
+
+      - step: "Create employer"
+        action: "create"
+        model: "res.partner"
+        save_as: "employer"
+        values:
+          name: "Test Portal Experience Employer"
+          is_company: true
+
+      - step: "Create portal experience record"
+        action: "create"
+        model: "portal_partner_experience"
+        save_as: "experience"
+        values:
+          partner_id: "REC: owner.id"
+          partner_address_id: "REC: employer.id"
+          date_start: 2020-01-01
+          job_position: "Engineer"
+
+      - step: "Assert record saved with the submitted values"
+        action: "assert"
+        target: "experience"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          partner_id:
+            type: "m2o"
+            expected: "REC: owner"
+          partner_address_id:
+            type: "m2o"
+            expected: "REC: employer"
+          date_start:
+            type: "value"
+            expected: 2020-01-01
+          job_position:
+            type: "value"
+            expected: "Engineer"
+
+  - name: "Update Job Level Persists the New Value"
+    steps:
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner2"
+        values:
+          name: "Test Portal Experience Owner 2"
+          is_company: false
+
+      - step: "Create portal experience record"
+        action: "create"
+        model: "portal_partner_experience"
+        save_as: "experience2"
+        values:
+          partner_id: "REC: owner2.id"
+          date_start: 2019-06-01
+          job_level: "Junior"
+
+      - step: "Update job level"
+        action: "write"
+        target: "experience2"
+        values:
+          job_level: "Senior"
+
+      - step: "Assert job level reflects the update"
+        action: "assert"
+        target: "experience2"
+        asserts:
+          job_level:
+            type: "value"
+            expected: "Senior"
+
+  - name: "Date End Before Date Start Is Rejected"
+    steps:
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner3"
+        values:
+          name: "Test Portal Experience Owner 3"
+          is_company: false
+
+      - step: "Create record with date_end before date_start"
+        action: "create"
+        model: "portal_partner_experience"
+        expect_error:
+          type: "UserError"
+          message_contains: "Date end must be greater than date start"
+        values:
+          partner_id: "REC: owner3.id"
+          date_start: 2022-01-01
+          date_end: 2021-01-01

--- a/ssi_partner_experience_portal/tests/test_portal_partner_academic.py
+++ b/ssi_partner_experience_portal/tests/test_portal_partner_academic.py
@@ -1,0 +1,38 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+from psycopg2 import IntegrityError
+
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestPortalPartnerAcademic(YamlTransactionCase):
+    """Scenario tests for ``portal_partner_academic``."""
+
+    def test_portal_partner_academic(self):
+        """Run the CRUD and constraint scenario for the model."""
+        self.run_yaml_scenario("test_data_portal_partner_academic.yaml")
+
+    @mute_logger("odoo.sql_db")
+    def test_partner_id_required(self):
+        """Reject a record created without the required ``partner_id``.
+
+        Pure Python — trigger P5 (L-22: ``psycopg2.IntegrityError`` is
+        outside the 12 error types ``expect_error`` understands, since
+        ``partner_id`` is only enforced by the NOT NULL column
+        constraint the ORM creates for ``required=True``, not by a
+        Python-level ``@api.constrains``).
+        ``mute_logger("odoo.sql_db")`` silences the PostgreSQL ERROR
+        line this deliberately triggers, so ``oca_checklog_odoo`` does
+        not fail the CI even though the test itself passes.
+        """
+        with self.assertRaises(IntegrityError):
+            self.env["portal_partner_academic"].create(
+                {
+                    "date_start": "2020-01-01",
+                }
+            )

--- a/ssi_partner_experience_portal/tests/test_portal_partner_experience.py
+++ b/ssi_partner_experience_portal/tests/test_portal_partner_experience.py
@@ -1,0 +1,38 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+from psycopg2 import IntegrityError
+
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestPortalPartnerExperience(YamlTransactionCase):
+    """Scenario tests for ``portal_partner_experience``."""
+
+    def test_portal_partner_experience(self):
+        """Run the CRUD and constraint scenario for the model."""
+        self.run_yaml_scenario("test_data_portal_partner_experience.yaml")
+
+    @mute_logger("odoo.sql_db")
+    def test_partner_id_required(self):
+        """Reject a record created without the required ``partner_id``.
+
+        Pure Python — trigger P5 (L-22: ``psycopg2.IntegrityError`` is
+        outside the 12 error types ``expect_error`` understands, since
+        ``partner_id`` is only enforced by the NOT NULL column
+        constraint the ORM creates for ``required=True``, not by a
+        Python-level ``@api.constrains``).
+        ``mute_logger("odoo.sql_db")`` silences the PostgreSQL ERROR
+        line this deliberately triggers, so ``oca_checklog_odoo`` does
+        not fail the CI even though the test itself passes.
+        """
+        with self.assertRaises(IntegrityError):
+            self.env["portal_partner_experience"].create(
+                {
+                    "date_start": "2020-01-01",
+                }
+            )

--- a/ssi_partner_experience_portal/views/assets.xml
+++ b/ssi_partner_experience_portal/views/assets.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template
         id="assets_frontend"
-        inherit_id="web_editor.assets_frontend"
+        inherit_id="web.assets_frontend"
         name="Portal Assets"
         priority="15"
     >

--- a/ssi_partner_experience_portal/views/portal_templates.xml
+++ b/ssi_partner_experience_portal/views/portal_templates.xml
@@ -142,7 +142,7 @@
                                 type="date"
                                 t-attf-class="form-control form-control-sm"
                                 name="date_start"
-                                required="required"
+                                required="1"
                                 t-att-value="current_academic_id.date_start"
                             />
                         </div>
@@ -389,7 +389,7 @@
                                 type="date"
                                 t-attf-class="form-control form-control-sm"
                                 name="date_start"
-                                required="required"
+                                required="1"
                                 t-att-value="current_experience_id.date_start"
                             />
                         </div>


### PR DESCRIPTION
## Ringkasan

Menuntaskan seluruh 14 temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-partner` (16 Agustus 2026) pada modul `ssi_partner_experience_portal`, tanpa mengubah perilaku fungsional.

- Tambah docstring pada seluruh class & method controller/model yang belum punya (validator `module`, 9 temuan).
- Ganti atribut `required="required"` literal jadi `required="1"` pada field `date_start` yang memang selalu wajib (validator `module`, 2 temuan).
- Daftarkan aset SCSS lewat template yang mewarisi `web.assets_frontend` (bukan `web_editor.assets_frontend`) agar terdeteksi validator `web`.
- Tambah direktori `tests/` dengan skenario CRUD, update field, dan constraint `date_end >= date_start` untuk `portal_partner_academic` dan `portal_partner_experience` (validator `unit-test`).
- Tambah `.validator-exceptions` untuk temuan validator `ik`: modul ini murni permukaan portal/website (arketipe E7, tanpa backend view/menu), sehingga IK & tour dinyatakan di luar cakupan — sama seperti preseden `ssi_partner_portal` (#69).

## Verifikasi

Keenam validator (`module`, `ik`, `po`, `web`, `unit-test`, `tour`) dijalankan lewat `pre-commit-gate.sh` sebelum commit — `GATE OK`, 0 pelanggaran baru.

## Test plan

- [ ] CI GitHub hijau (unit test skenario YAML dijalankan di CI, bukan lokal)

Closes #70