### PR TITLE
[UPD] ssi_partner_identification_portal - penuhi validator kepatuhan

### DIFF
--- a/ssi_partner_identification_portal/.validator-exceptions
+++ b/ssi_partner_identification_portal/.validator-exceptions
@@ -1,0 +1,8 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+#
+# Format: <validator> <kunci-temuan> -- <alasan>
+# Lihat skill odoo-development, references/validator-contract.md §13.
+
+ik modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali|docs/ -- Modul ini murni permukaan portal/website: satu-satunya cara pengguna mengoperasikan model portal_identification_number adalah controller @http.route (/my/identifications, /my/identification, /my/identification/remove) yang me-render template QWeb frontend; tidak ada ir.actions.act_window/menuitem/form view backend sama sekali (tak ada menu.xml di modul ini, satu-satunya <form> di views/portal_templates.xml adalah HTML form portal biasa, bukan ir.ui.view Odoo). Ini arketipe E7 pada skill odoo-development-instruksi-kerja (references/modul-extension.md) dan skill odoo-development-ui-test (references/scope-and-boundaries.md): IK dan tour untuk permukaan portal/website dinyatakan eksplisit di luar cakupan kedua skill tersebut, jadi direktori docs/ dengan format IK backend tidak dapat dibuat untuk model ini.

--- a/ssi_partner_identification_portal/controllers/portal.py
+++ b/ssi_partner_identification_portal/controllers/portal.py
@@ -13,10 +13,22 @@ _logger = logging.getLogger(__name__)
 
 
 class CustomerPortalExtended(CustomerPortal):
+    """
+    Extends the portal controller with identification number
+    self-service pages under ``/my/identifications``.
+    """
+
     @route(
         ["/my/identifications"], type="http", auth="user", website=True, methods=["GET"]
     )
     def identifications(self):
+        """Render the list of identification numbers of the partner.
+
+        :return: rendered
+            ``ssi_partner_identification_portal.portal_my_identifications``
+            page listing the ``portal_identification_number`` records
+            owned by the current user's partner
+        """
         values = self._prepare_portal_layout_values()
         values["get_error"] = portal.get_error
         values["id_numbers"] = request.env["portal_identification_number"].search(
@@ -37,6 +49,18 @@ class CustomerPortalExtended(CustomerPortal):
         methods=["GET", "POST"],
     )
     def identification(self, **post):
+        """Show, create, or update a single portal identification number.
+
+        On ``GET`` it renders the form (empty for a new record, or
+        pre-filled when ``id`` is given). On ``POST`` it validates
+        the submitted ``category`` reference, then creates or writes
+        the ``portal_identification_number`` record and redirects
+        back to the identification list.
+
+        :return: rendered
+            ``ssi_partner_identification_portal.portal_my_identification``
+            page, or a redirect to ``/my/identifications`` on success
+        """
         id = post.get("id")
         category_obj = request.env["res.partner.id_category"].sudo()
         partner_obj = request.env["res.partner"].sudo()
@@ -117,6 +141,10 @@ class CustomerPortalExtended(CustomerPortal):
         methods=["GET", "POST"],
     )
     def remove_identification(self, **post):
+        """Delete a portal identification number of the current user.
+
+        :return: redirect to ``/my/identifications``
+        """
         id = post.get("id")
         id_number_id = request.env["portal_identification_number"].search(
             [("id", "=", int(id))]

--- a/ssi_partner_identification_portal/models/portal_identification_number.py
+++ b/ssi_partner_identification_portal/models/portal_identification_number.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class PortalIdentificationNumber(models.Model):
+    """
+    Portal-facing view of ``res.partner.id_number`` used by the
+    identification self-service pages under ``/my/identifications``.
+    Shares the same database table as ``res.partner.id_number`` so
+    portal users manage the same records exposed in the backend,
+    scoped to their own partner through the security rules of this
+    module.
+    """
+
     _name = "portal_identification_number"
     _inherit = ["res.partner.id_number"]
     _description = "Portal Identification Number"

--- a/ssi_partner_identification_portal/tests/__init__.py
+++ b/ssi_partner_identification_portal/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_portal_identification_number  # noqa: F401

--- a/ssi_partner_identification_portal/tests/test_data_portal_identification_number.yaml
+++ b/ssi_partner_identification_portal/tests/test_data_portal_identification_number.yaml
@@ -1,0 +1,90 @@
+scenarios:
+  - name: "Create Portal Identification Number"
+    steps:
+      - step: "Create id category"
+        action: "create"
+        model: "res.partner.id_category"
+        save_as: "category"
+        values:
+          code: "test_id_category"
+          name: "Test ID Category"
+
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner"
+        values:
+          name: "Test Portal Identification Owner"
+          is_company: true
+
+      - step: "Create portal identification number"
+        action: "create"
+        model: "portal_identification_number"
+        save_as: "id_number"
+        values:
+          partner_id: "REC: owner.id"
+          category_id: "REC: category.id"
+          name: "ID-0001"
+          place_issuance: "Jakarta"
+
+      - step: "Assert record saved with the submitted values"
+        action: "assert"
+        target: "id_number"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          partner_id:
+            type: "m2o"
+            expected: "REC: owner"
+          category_id:
+            type: "m2o"
+            expected: "REC: category"
+          name:
+            type: "value"
+            expected: "ID-0001"
+          place_issuance:
+            type: "value"
+            expected: "Jakarta"
+
+  - name: "Update Place Of Issuance"
+    steps:
+      - step: "Create id category"
+        action: "create"
+        model: "res.partner.id_category"
+        save_as: "category"
+        values:
+          code: "test_id_category_2"
+          name: "Test ID Category 2"
+
+      - step: "Create owner partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "owner"
+        values:
+          name: "Test Portal Identification Owner 2"
+          is_company: true
+
+      - step: "Create portal identification number"
+        action: "create"
+        model: "portal_identification_number"
+        save_as: "id_number"
+        values:
+          partner_id: "REC: owner.id"
+          category_id: "REC: category.id"
+          name: "ID-0002"
+          place_issuance: "Bandung"
+
+      - step: "Update place of issuance"
+        action: "write"
+        target: "id_number"
+        values:
+          place_issuance: "Surabaya"
+
+      - step: "Assert place of issuance reflects the new value"
+        action: "assert"
+        target: "id_number"
+        asserts:
+          place_issuance:
+            type: "value"
+            expected: "Surabaya"

--- a/ssi_partner_identification_portal/tests/test_portal_identification_number.py
+++ b/ssi_partner_identification_portal/tests/test_portal_identification_number.py
@@ -1,0 +1,51 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+from psycopg2 import IntegrityError
+
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestPortalIdentificationNumber(YamlTransactionCase):
+    """Scenario tests for ``portal_identification_number``."""
+
+    def test_portal_identification_number(self):
+        """Run the CRUD scenario for the model."""
+        self.run_yaml_scenario("test_data_portal_identification_number.yaml")
+
+    @mute_logger("odoo.sql_db")
+    def test_name_required(self):
+        """Reject a record created without the required ``name``.
+
+        Pure Python -- trigger P5 (L-22: ``psycopg2.IntegrityError`` is
+        outside the 12 error types ``expect_error`` understands, since
+        ``name`` is only enforced by the NOT NULL column constraint
+        inherited from ``res.partner.id_number``, not by a
+        Python-level ``@api.constrains``).
+        ``mute_logger("odoo.sql_db")`` silences the PostgreSQL ERROR
+        line this deliberately triggers, so ``oca_checklog_odoo``
+        does not fail the CI even though the test itself passes.
+        """
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Test Missing Identification Name Owner",
+                "is_company": True,
+            }
+        )
+        category = self.env["res.partner.id_category"].create(
+            {
+                "code": "test_missing_name",
+                "name": "Test Missing Name Category",
+            }
+        )
+        with self.assertRaises(IntegrityError):
+            self.env["portal_identification_number"].create(
+                {
+                    "partner_id": partner.id,
+                    "category_id": category.id,
+                }
+            )

--- a/ssi_partner_identification_portal/views/assets.xml
+++ b/ssi_partner_identification_portal/views/assets.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template
         id="assets_frontend"
-        inherit_id="web_editor.assets_frontend"
+        inherit_id="web.assets_frontend"
         name="Portal Assets"
         priority="15"
     >

--- a/ssi_partner_identification_portal/views/portal_templates.xml
+++ b/ssi_partner_identification_portal/views/portal_templates.xml
@@ -149,11 +149,7 @@
                         />
                         <div class="form-group">
                             <label for="category">Category:</label>
-                            <select
-                                class="form-control"
-                                name="category"
-                                required="required"
-                            >
+                            <select class="form-control" name="category" required="1">
                                 <option value="" />
                                 <t t-foreach="category_ids" t-as="category_id">
                                     <option
@@ -170,7 +166,7 @@
                                 type="text"
                                 t-attf-class="form-control form-control-sm"
                                 name="name"
-                                required="required"
+                                required="1"
                                 t-att-value="current_id_number_id.name"
                             />
                         </div>


### PR DESCRIPTION
## Ringkasan

Memenuhi keenam validator kepatuhan (`module`, `ik`, `po`, `web`, `unit-test`, `tour`) untuk modul `ssi_partner_identification_portal` tanpa mengubah perilaku fungsional apa pun.

- Ganti atribut `required="required"` (tidak sah di seri 14.0) menjadi `required="1"` pada `views/portal_templates.xml` (field Category & ID Number selalu wajib, bukan kondisi dinamis)
- Daftarkan aset SCSS lewat template yang mewarisi `web.assets_frontend` (bukan `web_editor.assets_frontend`)
- Tambahkan docstring pada class controller `CustomerPortalExtended` beserta method `identifications`/`identification`/`remove_identification`, dan pada class model `PortalIdentificationNumber`
- Tambahkan direktori `tests/` dengan skenario CRUD + negative path (field wajib `name`) untuk model `portal_identification_number`
- Tambahkan `.validator-exceptions` untuk aturan IK `docs/` — modul ini murni permukaan portal/website (arketipe E7, sama seperti `ssi_partner_portal` #69 dan `ssi_partner_experience_portal` #70): tidak ada `ir.actions.act_window`/`menuitem`/form view backend sama sekali, sehingga IK & tour backend di luar cakupan

## Verifikasi

Keenam validator lolos `0 ERROR` setelah perubahan (lihat komentar issue untuk baris `#VALIDATOR` mentah).

Closes #71