### PR TITLE
[UPD] ssi_partner_creditor_debitor - lengkapi kepatuhan validator (docstring, inline form, IK, tour)

### DIFF
--- a/ssi_partner_creditor_debitor/README.rst
+++ b/ssi_partner_creditor_debitor/README.rst
@@ -19,6 +19,11 @@ To install this module, you need to:
 5.  Search For *Partner Creditor and Debitor Information*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Create Contact <docs/res_partner/index.html>`_
+
 Bug Tracker
 ===========
 

--- a/ssi_partner_creditor_debitor/__manifest__.py
+++ b/ssi_partner_creditor_debitor/__manifest__.py
@@ -13,11 +13,13 @@
     "depends": [
         "ssi_master_data_mixin",
         "ssi_partner",
+        "web_tour",
     ],
     "data": [
         "security/ir.model.access.csv",
         "data/res_partner_category_data.xml",
         "views/res_partner_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
     "contributors": [

--- a/ssi_partner_creditor_debitor/docs/res_partner/01-create.md
+++ b/ssi_partner_creditor_debitor/docs/res_partner/01-create.md
@@ -1,0 +1,21 @@
+# Create Contact
+
+> **Module:** ssi_partner_creditor_debitor\
+> **Extends:** res.partner (Odoo core Contacts) — no base Instruksi Kerja exists for this
+> model
+
+## Additional Fields
+
+When this module is installed, the Contacts form gains a **Creditor & Debtor** page:
+
+- **Primary Creditor**: Read-only. Automatically shows the **Creditor** of the first row
+  (by **Sequence**) in the **Creditors** list below. Empty when that list has no rows.
+- **Creditors**: One or more contacts this contact owes money to. Optional — zero or
+  more rows may be added. Each row has:
+  - **Sequence**: Drag handle used to reorder the rows; the top row determines **Primary
+    Creditor**. Defaults to `10`.
+  - **Creditor**: The creditor contact, selected only from contacts in the **Creditor**
+    category. Required per row.
+- **Debtors**: One or more contacts that owe money to this contact. Optional — zero or
+  more rows may be added. Each row has:
+  - **Debtor**: The debtor contact. Not restricted to any category. Required per row.

--- a/ssi_partner_creditor_debitor/models/partner_creditor_debtor.py
+++ b/ssi_partner_creditor_debitor/models/partner_creditor_debtor.py
@@ -6,6 +6,13 @@ from odoo import fields, models
 
 
 class PartnerCreditorDebtor(models.Model):
+    """
+    Represents a single creditor/debtor relationship between two
+    ``res.partner`` records. Each record links one partner acting as
+    creditor to another partner acting as debtor, and is edited inline
+    from the Creditor & Debtor tab of either partner's form.
+    """
+
     _name = "partner_creditor_debtor"
     _description = "Partner Creditors Debtors"
     _order = "sequence, id"

--- a/ssi_partner_creditor_debitor/models/res_partner.py
+++ b/ssi_partner_creditor_debitor/models/res_partner.py
@@ -7,6 +7,13 @@ from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
+    """
+    Adds creditor/debtor tracking to contacts.
+    Lets a contact list which other contacts are its creditors and
+    which are its debtors, and exposes the primary (first-sequence)
+    creditor as a dedicated field for quick reference.
+    """
+
     _name = "res.partner"
     _inherit = "res.partner"
 
@@ -34,6 +41,12 @@ class ResPartner(models.Model):
         "creditor_ids.creditor_id",
     )
     def _compute_primary_creditor_id(self):
+        """Set ``primary_creditor_id`` to the first creditor in line.
+
+        The first row of ``creditor_ids``, ordered by ``sequence``, is
+        taken as the partner's primary creditor. Falls back to
+        ``False`` when no creditor row exists.
+        """
         for record in self:
             result = False
             if record.creditor_ids:

--- a/ssi_partner_creditor_debitor/static/tests/tours/res_partner_tour.js
+++ b/ssi_partner_creditor_debitor/static/tests/tours/res_partner_tour.js
@@ -1,0 +1,76 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_creditor_debitor.res_partner_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/res_partner/01-create.md (E1 delta -- Additional Fields)
+    //
+    // res.partner is Odoo core Contacts, so there is no base Instruksi
+    // Kerja with navigation steps to reuse. This tour writes the standard
+    // Contacts navigation itself: open the Contacts app, click Create,
+    // then assert the Creditor & Debtor tab this module adds.
+    tour.register(
+        "ssi_partner_creditor_debitor_res_partner_field_creditor_debtor",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Open the Contacts app. The Contacts app tile has no
+            // action of its own; it redirects straight to the Contacts
+            // action (its only actionable child menu), so there is no
+            // intermediate landing view to race against.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                // Gate: wait for the Contacts action to actually be
+                // mounted. The Contacts action's view_mode starts with
+                // "kanban", so the landing view is Kanban, not List.
+                content: "Contacts kanban view is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Contacts)",
+                extra_trigger: ".o_kanban_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Click Create. The Contacts kanban view's Create button
+            // uses the kanban-specific class, not the list one.
+            {
+                content: "Click Create",
+                trigger: ".o-kanban-button-new",
+                extra_trigger: ".o_kanban_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Additional Fields (docs/res_partner/01-create.md, delta of
+            // ssi_partner_creditor_debitor) -- the Creditor & Debtor page
+            // is always visible (no attrs gate it). Delta-only tour: it
+            // stops here, it does not fill any field and does not
+            // continue to Save (E1 delta-only; see
+            // odoo-development-ui-test scope-and-boundaries.md).
+            {
+                content: "Creditor & Debtor tab is displayed",
+                trigger:
+                    ".o_notebook_headers li.nav-item:not(.o_invisible_modifier)" +
+                    " > a.nav-link:contains(Creditor & Debtor)",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_partner_creditor_debitor/tests/__init__.py
+++ b/ssi_partner_creditor_debitor/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_creditor_debitor  # noqa: F401
+from . import test_ui_res_partner  # noqa: F401

--- a/ssi_partner_creditor_debitor/tests/test_creditor_debitor.py
+++ b/ssi_partner_creditor_debitor/tests/test_creditor_debitor.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestCreditorDebitor(YamlTransactionCase):
+    """Cover the creditor/debitor relationship on ``res.partner``."""
+
     def test_creditor_debitor(self):
+        """Run the create-relationship scenario for creditor/debtor."""
         self.run_yaml_scenario("test_data_creditor_debitor.yaml")

--- a/ssi_partner_creditor_debitor/tests/test_ui_res_partner.py
+++ b/ssi_partner_creditor_debitor/tests/test_ui_res_partner.py
@@ -1,0 +1,21 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiResPartner(HttpSavepointCase):
+    """Tour test for the ``res.partner`` Creditor & Debtor field delta."""
+
+    def test_field_creditor_debtor(self):
+        """Run the delta tour for the Contacts create form.
+
+        IK: docs/res_partner/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_creditor_debitor_res_partner_field_creditor_debtor",
+            login="admin",
+        )

--- a/ssi_partner_creditor_debitor/views/assets.xml
+++ b/ssi_partner_creditor_debitor/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_partner_creditor_debitor assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_partner_creditor_debitor/static/tests/tours/res_partner_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/ssi_partner_creditor_debitor/views/res_partner_views.xml
+++ b/ssi_partner_creditor_debitor/views/res_partner_views.xml
@@ -18,12 +18,26 @@
                                 domain="[('category_id','=',%(res_partner_category_creditor)d)]"
                             />
                     </tree>
+                    <form>
+                        <group>
+                            <field name="sequence" />
+                            <field
+                                    name="creditor_id"
+                                    domain="[('category_id','=',%(res_partner_category_creditor)d)]"
+                                />
+                        </group>
+                    </form>
                 </field>
                 <group name="debtor" string="Debtors" colspan="4" col="2" />
                 <field name="debtor_ids">
                     <tree editable="bottom">
                         <field name="debtor_id" />
                     </tree>
+                    <form>
+                        <group>
+                            <field name="debtor_id" />
+                        </group>
+                    </form>
                 </field>
             </page>
         </xpath>


### PR DESCRIPTION
## Ringkasan

Memenuhi 10 temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-partner` pada
modul `ssi_partner_creditor_debitor`, tanpa mengubah perilaku fungsional apa pun:

- Tambah docstring pada seluruh class & method yang belum terdokumentasi (`module`)
- Tambah inline `<form>` pada field one2many `creditor_ids` dan `debtor_ids` di form
  `res.partner`, mendampingi inline `<tree>` yang sudah ada (`module`)
- Tambah Instruksi Kerja delta `docs/res_partner/01-create.md` untuk field Creditor &
  Debtor yang ditambahkan modul ini pada `res.partner` (`ik`)
- Tambah tour UI (`static/tests/tours/res_partner_tour.js`) beserta test HttpCase-nya
  (`tests/test_ui_res_partner.py`) sebagai pasangan wajib IK di atas
- Tambah dependensi `web_tour` dan bundle `views/assets.xml` untuk tour test
- Perbarui `README.rst` dengan bagian Work Instruction

Tidak ada field/method/model yang berganti nama; tidak ada test/tour yang dihapus atau
dilonggarkan.

## Bukti validator (setelah perubahan)

```
#VALIDATOR name=module    target=ssi_partner_creditor_debitor series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_partner_creditor_debitor series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_partner_creditor_debitor series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_partner_creditor_debitor series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-partner modules=1 failed=0 skipped=0 status=OK
```

Closes #72