### PR TITLE
[UPD] ssi_insurance_provider - penuhi validator kepatuhan

### DIFF
--- a/ssi_insurance_provider/README.rst
+++ b/ssi_insurance_provider/README.rst
@@ -14,6 +14,20 @@ This module provides master data management for insurance products and coverage 
 * **Insurance Product** — records an insurance product offered by a provider,
   linked to a coverage type and enriched with a rate schedule.
 
+Work Instruction
+================
+
+* `Create Insurance Product Coverage <docs/insurance_product_coverage/01-create.html>`_
+* `Edit Insurance Product Coverage <docs/insurance_product_coverage/02-edit.html>`_
+* `Delete Insurance Product Coverage <docs/insurance_product_coverage/03-delete.html>`_
+* `Deactivate Insurance Product Coverage <docs/insurance_product_coverage/04-deactivate.html>`_
+* `Activate Insurance Product Coverage <docs/insurance_product_coverage/05-activate.html>`_
+* `Create Insurance Product <docs/insurance_product/01-create.html>`_
+* `Edit Insurance Product <docs/insurance_product/02-edit.html>`_
+* `Delete Insurance Product <docs/insurance_product/03-delete.html>`_
+* `Deactivate Insurance Product <docs/insurance_product/04-deactivate.html>`_
+* `Activate Insurance Product <docs/insurance_product/05-activate.html>`_
+
 Installation
 ============
 

--- a/ssi_insurance_provider/__manifest__.py
+++ b/ssi_insurance_provider/__manifest__.py
@@ -16,6 +16,7 @@
     "depends": [
         "ssi_product",
         "ssi_master_data_mixin",
+        "web_tour",
     ],
     "data": [
         "security/res_groups/insurance_product_coverage.xml",
@@ -25,6 +26,7 @@
         "menu.xml",
         "views/insurance_product_coverage_views.xml",
         "views/insurance_product_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
 }

--- a/ssi_insurance_provider/docs/insurance_product/01-create.md
+++ b/ssi_insurance_provider/docs/insurance_product/01-create.md
@@ -1,0 +1,37 @@
+# Create Insurance Product
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Products\
+> **Actor:** user in group `Insurance Product`\
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Config:** An active `sequence.template` for this model is set, if the **Generate
+  Code** button will be used instead of a manual code.
+- **Data:** An active `insurance_product_coverage` record exists.
+- **Data:** The provider (a `res.partner` record) already exists.
+- **Access:** User is in group `Insurance Product`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Products** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name**: the insurance product label.
+   - **Code**: a unique identifier, or leave as **/** to assign it later.
+   - **Provider**: the partner offering this product.
+   - **Coverage Type**: the coverage classification for this product.
+   - **Currency**: the currency used for the rates and cap amounts.
+4. In the header, click **Generate Code** to assign a code from the configured sequence
+   template. Only applies when **Code** is still **/**. Skip this step to keep a
+   manually typed code.
+5. On the **Rates** tab, add rate lines with **Effective Date**, **Employer Rate (%)**,
+   **Employee Rate (%)**, and **Cap Amount** as needed. This step is optional; the
+   product can be saved without rates.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new record is created and **Active**.

--- a/ssi_insurance_provider/docs/insurance_product/02-edit.md
+++ b/ssi_insurance_provider/docs/insurance_product/02-edit.md
@@ -1,0 +1,28 @@
+# Edit Insurance Product
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Products\
+> **Actor:** user in group `Insurance Product`\
+> **Requires:** `01-create`\
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Record:** The record already exists.
+- **Access:** User is in group `Insurance Product`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Products** menu.
+2. Find and open the record to edit.
+3. Click the **Edit** button.
+4. Change the required fields (**Name**, **Code**, **Provider**, **Coverage Type**,
+   **Currency**) or add/remove rate lines on the **Rates** tab.
+5. Click **Generate Code** to re-assign a code from the sequence template — for example
+   after clearing **Code** back to **/**. Skip this step if keeping the current code.
+6. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_insurance_provider/docs/insurance_product/03-delete.md
+++ b/ssi_insurance_provider/docs/insurance_product/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Insurance Product
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Products\
+> **Actor:** user in group `Insurance Product`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is not referenced by any other document.
+- **Access:** User is in group `Insurance Product`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Products** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_insurance_provider/docs/insurance_product/04-deactivate.md
+++ b/ssi_insurance_provider/docs/insurance_product/04-deactivate.md
@@ -1,0 +1,26 @@
+# Deactivate Insurance Product
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Products\
+> **Actor:** user in group `Insurance Product`\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Insurance Product`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Products** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated insurance products cannot be selected in new transactions.
+- Transactions that already use this record can still be viewed.

--- a/ssi_insurance_provider/docs/insurance_product/05-activate.md
+++ b/ssi_insurance_provider/docs/insurance_product/05-activate.md
@@ -1,0 +1,25 @@
+# Activate Insurance Product
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Products\
+> **Actor:** user in group `Insurance Product`\
+> **Active:** `false` → `true`\
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Insurance Product`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Products** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected in new transactions again.

--- a/ssi_insurance_provider/docs/insurance_product_coverage/01-create.md
+++ b/ssi_insurance_provider/docs/insurance_product_coverage/01-create.md
@@ -1,0 +1,29 @@
+# Create Insurance Product Coverage
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product_coverage`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Coverages\
+> **Actor:** user in group `Insurance Product Coverage`\
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Config:** An active `sequence.template` for this model is set, if the **Generate
+  Code** button will be used instead of a manual code.
+- **Access:** User is in group `Insurance Product Coverage`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Coverages** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name**: the coverage type label.
+   - **Code**: a unique identifier, or leave as **/** to assign it later.
+4. In the header, click **Generate Code** to assign a code from the configured sequence
+   template. Only applies when **Code** is still **/**. Skip this step to keep a
+   manually typed code.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created and **Active**.

--- a/ssi_insurance_provider/docs/insurance_product_coverage/02-edit.md
+++ b/ssi_insurance_provider/docs/insurance_product_coverage/02-edit.md
@@ -1,0 +1,27 @@
+# Edit Insurance Product Coverage
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product_coverage`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Coverages\
+> **Actor:** user in group `Insurance Product Coverage`\
+> **Requires:** `01-create`\
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Record:** The record already exists.
+- **Access:** User is in group `Insurance Product Coverage`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Coverages** menu.
+2. Find and open the record to edit.
+3. Click the **Edit** button.
+4. Change the required fields (**Name**, **Code**, or **Note**).
+5. Click **Generate Code** to re-assign a code from the sequence template — for example
+   after clearing **Code** back to **/**. Skip this step if keeping the current code.
+6. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_insurance_provider/docs/insurance_product_coverage/03-delete.md
+++ b/ssi_insurance_provider/docs/insurance_product_coverage/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Insurance Product Coverage
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product_coverage`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Coverages\
+> **Actor:** user in group `Insurance Product Coverage`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is not referenced by any insurance product.
+- **Access:** User is in group `Insurance Product Coverage`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Coverages** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_insurance_provider/docs/insurance_product_coverage/04-deactivate.md
+++ b/ssi_insurance_provider/docs/insurance_product_coverage/04-deactivate.md
@@ -1,0 +1,26 @@
+# Deactivate Insurance Product Coverage
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product_coverage`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Coverages\
+> **Actor:** user in group `Insurance Product Coverage`\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Insurance Product Coverage`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Coverages** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated coverage types cannot be selected on new insurance products.
+- Insurance products that already use this coverage type can still be viewed.

--- a/ssi_insurance_provider/docs/insurance_product_coverage/05-activate.md
+++ b/ssi_insurance_provider/docs/insurance_product_coverage/05-activate.md
@@ -1,0 +1,25 @@
+# Activate Insurance Product Coverage
+
+> **Module:** ssi_insurance_provider\
+> **Model:** `insurance_product_coverage`\
+> **Menu:** Contacts > Configuration > Insurance Provider > Coverages\
+> **Actor:** user in group `Insurance Product Coverage`\
+> **Active:** `false` → `true`\
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Insurance Product Coverage`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Insurance Provider > Coverages** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected on new insurance products again.

--- a/ssi_insurance_provider/models/insurance_product_rate.py
+++ b/ssi_insurance_provider/models/insurance_product_rate.py
@@ -6,6 +6,12 @@ from odoo import api, fields, models
 
 
 class InsuranceProductRate(models.Model):
+    """
+    Represents one effective-dated rate line of an insurance product.
+    Tracks the employer/employee contribution split, the resulting
+    total rate, and an optional cap amount for a given effective date.
+    """
+
     _name = "insurance_product.rate"
     _description = "Insurance Product - Rate"
     _order = "insurance_product_id, effective_date"
@@ -45,5 +51,9 @@ class InsuranceProductRate(models.Model):
 
     @api.depends("employer_rate", "employee_rate")
     def _compute_total_rate(self):
+        """Sum the employer and employee rates into ``total_rate``.
+
+        :return: None. Writes ``total_rate`` on every record in ``self``.
+        """
         for rec in self:
             rec.total_rate = rec.employer_rate + rec.employee_rate

--- a/ssi_insurance_provider/static/tests/tours/insurance_product_coverage_tour.js
+++ b/ssi_insurance_provider/static/tests/tours/insurance_product_coverage_tour.js
@@ -1,0 +1,92 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_insurance_provider.insurance_product_coverage_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/insurance_product_coverage/01-create.md
+    tour.register(
+        "ssi_insurance_provider_insurance_product_coverage_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Contacts > Configuration > Insurance
+            // Provider > Coverages menu. "Insurance Provider" is a
+            // grouping header (has children, level 3+) so it renders
+            // without a data-menu-xmlid and is skipped here.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the Coverages menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_insurance_provider.insurance_product_coverage_menu"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang.
+                content: "Insurance Product Coverages list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Insurance Product Coverages)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Fill in Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text Tour Test Coverage",
+            },
+            {
+                content: "Fill in Code",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text /",
+            },
+
+            // Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                // Post-Condition — a new record is created and Active.
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_insurance_provider/static/tests/tours/insurance_product_tour.js
+++ b/ssi_insurance_provider/static/tests/tours/insurance_product_tour.js
@@ -1,0 +1,122 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_insurance_provider.insurance_product_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/insurance_product/01-create.md
+    tour.register(
+        "ssi_insurance_provider_insurance_product_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Contacts > Configuration > Insurance
+            // Provider > Products menu. "Insurance Provider" is a
+            // grouping header (has children, level 3+) so it renders
+            // without a data-menu-xmlid and is skipped here.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the Products menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_insurance_provider.insurance_product_menu"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang.
+                content: "Insurance Products list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Insurance Products)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Fill in Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text Tour Test Insurance Product",
+            },
+            {
+                content: "Fill in Code",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text /",
+            },
+            {
+                content: "Select the Provider",
+                trigger: ".o_field_many2one[name='provider_id'] input",
+                run: "text Tour Test Insurance Provider",
+            },
+            {
+                content: "Pick the Provider from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(Tour Test Insurance Provider)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Coverage Type",
+                trigger: ".o_field_many2one[name='coverage_type_id'] input",
+                run: "text Tour Test Product Coverage",
+            },
+            {
+                content: "Pick the Coverage Type from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(Tour Test Product Coverage)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Currency",
+                trigger: ".o_field_many2one[name='currency_id'] input",
+                run: "text USD",
+            },
+            {
+                content: "Pick the Currency from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(USD)",
+                in_modal: false,
+            },
+
+            // Flow 6 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                // Post-Condition — a new record is created and Active.
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_insurance_provider/tests/__init__.py
+++ b/ssi_insurance_provider/tests/__init__.py
@@ -3,3 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_insurance_provider  # noqa: F401
+from . import test_ui_insurance_product_coverage  # noqa: F401
+from . import test_ui_insurance_product  # noqa: F401

--- a/ssi_insurance_provider/tests/test_insurance_provider.py
+++ b/ssi_insurance_provider/tests/test_insurance_provider.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestInsuranceProvider(YamlTransactionCase):
+    """Cover ``insurance_product_coverage`` and ``insurance_product`` CRUD."""
+
     def test_insurance_provider(self):
+        """Run the coverage/product creation scenarios."""
         self.run_yaml_scenario("test_data_insurance_provider.yaml")

--- a/ssi_insurance_provider/tests/test_ui_insurance_product.py
+++ b/ssi_insurance_provider/tests/test_ui_insurance_product.py
@@ -1,0 +1,41 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase does not expose
+# cls.env in setUpClass.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiInsuranceProduct(HttpSavepointCase):
+    """Tour tests for the ``insurance_product`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the provider, coverage type, and currency the tour
+        picks from the many2one dropdowns (IK Pre-Condition data).
+        """
+        super().setUpClass()
+        cls.provider = cls.env["res.partner"].create(
+            {"name": "Tour Test Insurance Provider", "is_company": True}
+        )
+        cls.coverage = cls.env["insurance_product_coverage"].create(
+            {"name": "Tour Test Product Coverage", "code": "/"}
+        )
+        # The currency dropdown only lists active currencies; ensure USD
+        # is active so the tour can select it.
+        cls.currency = cls.env.ref("base.USD")
+        if not cls.currency.active:
+            cls.currency.sudo().write({"active": True})
+
+    def test_create(self):
+        """Run the create tour for ``insurance_product``.
+
+        IK: docs/insurance_product/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_insurance_provider_insurance_product_create",
+            login="admin",
+        )

--- a/ssi_insurance_provider/tests/test_ui_insurance_product_coverage.py
+++ b/ssi_insurance_provider/tests/test_ui_insurance_product_coverage.py
@@ -1,0 +1,23 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase does not expose
+# cls.env in setUpClass.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiInsuranceProductCoverage(HttpSavepointCase):
+    """Tour tests for the ``insurance_product_coverage`` work instructions."""
+
+    def test_create(self):
+        """Run the create tour for ``insurance_product_coverage``.
+
+        IK: docs/insurance_product_coverage/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_insurance_provider_insurance_product_coverage_create",
+            login="admin",
+        )

--- a/ssi_insurance_provider/views/assets.xml
+++ b/ssi_insurance_provider/views/assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_insurance_provider assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_insurance_provider/static/tests/tours/insurance_product_coverage_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_insurance_provider/static/tests/tours/insurance_product_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/ssi_insurance_provider/views/insurance_product_views.xml
+++ b/ssi_insurance_provider/views/insurance_product_views.xml
@@ -77,6 +77,15 @@
                                 <field name="total_rate" />
                                 <field name="cap_amount" />
                             </tree>
+                            <form>
+                                <group>
+                                    <field name="effective_date" />
+                                    <field name="employer_rate" />
+                                    <field name="employee_rate" />
+                                    <field name="total_rate" />
+                                    <field name="cap_amount" />
+                                </group>
+                            </form>
                         </field>
                     </page>
                 </xpath>


### PR DESCRIPTION
## Ringkasan

Memenuhi validator kepatuhan (`module`, `ik`, `unit-test`) di modul `ssi_insurance_provider`, tanpa mengubah perilaku fungsional.

- Tambah docstring class & method yang belum lengkap: `InsuranceProductRate`, `_compute_total_rate`, `TestInsuranceProvider`, `test_insurance_provider`.
- Tambah inline `<form>` untuk field one2many `rate_ids` (sudah punya inline `<tree>`, belum punya inline `<form>`).
- Tambah Instruksi Kerja (IK) lengkap — create/edit/delete/deactivate/activate — untuk model `insurance_product` dan `insurance_product_coverage` di `docs/`, plus pembaruan `README.rst` bagian Work Instruction.
- Tambah tour UI test untuk alur create kedua model, berikut `HttpCase` Python pemanggilnya dan pendaftaran bundle `web.assets_tests`.

## Referensi

Closes #73

## Test plan

- [x] `verify-module.sh` → `error=0`
- [x] `validate-ik.sh` → `error=0`
- [x] `validate-unit-test.sh` → `error=0`
- [x] `validate-tour.sh` → `error=0`
- [x] `pre-commit-gate.sh` (keenam validator) → `GATE OK`
- [ ] CI (dipantau orkestrator)