### PR TITLE
[UPD] ssi_partner_data_privacy_consent - penuhi validator kepatuhan

### DIFF
--- a/ssi_partner_data_privacy_consent/README.rst
+++ b/ssi_partner_data_privacy_consent/README.rst
@@ -19,6 +19,13 @@ Both master data are available under *Contacts -> Configuration -> Data
 Privacy* and are meant to be referenced by partner consent records.
 
 
+Work Instruction
+================
+
+* `Consent Purpose <docs/partner_consent_purpose/index.html>`_
+* `Privacy Notice <docs/partner_consent_notice/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_partner_data_privacy_consent/__manifest__.py
+++ b/ssi_partner_data_privacy_consent/__manifest__.py
@@ -12,11 +12,13 @@
     "application": False,
     "depends": [
         "ssi_partner",
+        "web_tour",
     ],
     "data": [
         "security/res_group_data.xml",
         "security/ir.model.access.csv",
         "menu.xml",
+        "views/assets.xml",
         "views/partner_consent_purpose_views.xml",
         "views/partner_consent_notice_views.xml",
         "views/res_partner_views.xml",

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_notice/01-create.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_notice/01-create.md
@@ -1,0 +1,36 @@
+# Create Privacy Notice
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_notice`\
+> **Menu:** Contacts > Configuration > Data Privacy > Privacy Notice\
+> **Actor:** user in group `Partner Consent Privacy Notice`
+
+## Pre-Condition
+
+- **Access:** User is in group `Partner Consent Privacy Notice`.
+- **Data:** (optional) At least one `partner_consent_purpose` record exists, if this
+  notice needs to reference purposes.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Privacy Notice** menu.
+2. Click the **Create** button.
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter the name of the privacy notice.
+   - **Code** _(required)_: Enter a unique code, or enter **/** to leave it unassigned
+     for now.
+4. Open the **Privacy Notice** tab and fill in:
+   - **Version** _(required)_: Enter the version identifier of this notice document.
+   - **Effective Date** _(required)_: Defaults to today's date; change if the notice
+     takes effect on a different date.
+   - **Purposes**: Optionally select one or more `partner_consent_purpose` records
+     covered by this notice.
+   - **Body** _(required)_: Enter the exact text of the privacy notice.
+5. Optionally fill in the **Note** tab with free-text notes.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new **Privacy Notice** record is created and appears in the Privacy Notice list.
+- The record becomes selectable as a **Privacy Notice** on `res.partner.consent`
+  records.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_notice/02-edit.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_notice/02-edit.md
@@ -1,0 +1,24 @@
+# Edit Privacy Notice
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_notice`\
+> **Menu:** Contacts > Configuration > Data Privacy > Privacy Notice\
+> **Actor:** user in group `Partner Consent Privacy Notice`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record to edit already exists.
+- **Access:** User is in group `Partner Consent Privacy Notice`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Privacy Notice** menu.
+2. Find and open the record to edit.
+3. Change the **Name**, **Code**, **Version**, **Effective Date**, **Purposes**,
+   **Body**, or **Note** fields as needed.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_notice/03-delete.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_notice/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Privacy Notice
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_notice`\
+> **Menu:** Contacts > Configuration > Data Privacy > Privacy Notice\
+> **Actor:** user in group `Partner Consent Privacy Notice`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is not referenced by any `res.partner.consent` record (the
+  relation is `ondelete="restrict"`).
+- **Access:** User is in group `Partner Consent Privacy Notice`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Privacy Notice** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_notice/04-deactivate.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_notice/04-deactivate.md
@@ -1,0 +1,26 @@
+# Deactivate Privacy Notice
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_notice`\
+> **Menu:** Contacts > Configuration > Data Privacy > Privacy Notice\
+> **Actor:** user in group `Partner Consent Privacy Notice`\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Partner Consent Privacy Notice`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Privacy Notice** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated notices cannot be selected on new `res.partner.consent` records.
+- Consents that already reference this notice can still be viewed.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_notice/05-activate.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_notice/05-activate.md
@@ -1,0 +1,25 @@
+# Activate Privacy Notice
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_notice`\
+> **Menu:** Contacts > Configuration > Data Privacy > Privacy Notice\
+> **Actor:** user in group `Partner Consent Privacy Notice`\
+> **Active:** `false` → `true`\
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Partner Consent Privacy Notice`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Privacy Notice** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected again on new `res.partner.consent` records.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/01-create.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/01-create.md
@@ -1,0 +1,27 @@
+# Create Consent Purpose
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_purpose`\
+> **Menu:** Contacts > Configuration > Data Privacy > Consent Purpose\
+> **Actor:** user in group `Partner Consent Purpose`
+
+## Pre-Condition
+
+- **Access:** User is in group `Partner Consent Purpose`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Consent Purpose** menu.
+2. Click the **Create** button.
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter the name of the data-processing purpose.
+   - **Code** _(required)_: Enter a unique code, or enter **/** to leave it unassigned
+     for now.
+4. Optionally fill in the **Note** tab with free-text notes.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new **Consent Purpose** record is created and appears in the Consent Purpose list.
+- The record becomes selectable as a **Purpose** on `partner_consent_notice` and
+  `res.partner.consent` records.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/02-edit.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/02-edit.md
@@ -1,0 +1,23 @@
+# Edit Consent Purpose
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_purpose`\
+> **Menu:** Contacts > Configuration > Data Privacy > Consent Purpose\
+> **Actor:** user in group `Partner Consent Purpose`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record to edit already exists.
+- **Access:** User is in group `Partner Consent Purpose`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Consent Purpose** menu.
+2. Find and open the record to edit.
+3. Change the **Name**, **Code**, or **Note** fields as needed.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/03-delete.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Consent Purpose
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_purpose`\
+> **Menu:** Contacts > Configuration > Data Privacy > Consent Purpose\
+> **Actor:** user in group `Partner Consent Purpose`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is not referenced by any `partner_consent_notice` or
+  `res.partner.consent` record.
+- **Access:** User is in group `Partner Consent Purpose`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Consent Purpose** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/04-deactivate.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/04-deactivate.md
@@ -1,0 +1,27 @@
+# Deactivate Consent Purpose
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_purpose`\
+> **Menu:** Contacts > Configuration > Data Privacy > Consent Purpose\
+> **Actor:** user in group `Partner Consent Purpose`\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Partner Consent Purpose`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Consent Purpose** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated purposes cannot be selected on new `partner_consent_notice` or
+  `res.partner.consent` records.
+- Notices and consents that already reference this purpose can still be viewed.

--- a/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/05-activate.md
+++ b/ssi_partner_data_privacy_consent/docs/partner_consent_purpose/05-activate.md
@@ -1,0 +1,26 @@
+# Activate Consent Purpose
+
+> **Module:** ssi_partner_data_privacy_consent\
+> **Model:** `partner_consent_purpose`\
+> **Menu:** Contacts > Configuration > Data Privacy > Consent Purpose\
+> **Actor:** user in group `Partner Consent Purpose`\
+> **Active:** `false` → `true`\
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Partner Consent Purpose`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Data Privacy > Consent Purpose** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected again on new `partner_consent_notice` or
+  `res.partner.consent` records.

--- a/ssi_partner_data_privacy_consent/models/res_partner.py
+++ b/ssi_partner_data_privacy_consent/models/res_partner.py
@@ -6,6 +6,12 @@ from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
+    """
+    Adds data privacy consent tracking to partner records.
+    Exposes the append-only consent log and the set of purposes
+    currently granted, derived from that log.
+    """
+
     _name = "res.partner"
     _inherit = "res.partner"
 
@@ -33,6 +39,14 @@ class ResPartner(models.Model):
         "consent_ids.consent_date",
     )
     def _compute_active_consent_purpose_ids(self):
+        """Derive the purposes currently granted from the consent log.
+
+        For each purpose, only the most recent consent event (by
+        ``consent_date`` desc) determines whether it is active: a
+        purpose is active when that event's ``consent_type`` is
+        ``grant``, and inactive when it is ``withdraw`` or has no
+        event at all.
+        """
         for record in self:
             active = self.env["partner_consent_purpose"]
             seen = set()

--- a/ssi_partner_data_privacy_consent/models/res_partner_consent.py
+++ b/ssi_partner_data_privacy_consent/models/res_partner_consent.py
@@ -87,6 +87,15 @@ class ResPartnerConsent(models.Model):
     )
 
     def write(self, vals):
+        """Block modification of consent records by non-superuser calls.
+
+        Consent events must stay immutable to keep the log an
+        auditable trail. Withdrawing consent means creating a new
+        record with ``consent_type`` "withdraw", never editing an
+        existing one.
+
+        :raises UserError: when called without ``self.env.su``
+        """
         if not self.env.su:
             raise UserError(
                 _(
@@ -98,6 +107,13 @@ class ResPartnerConsent(models.Model):
         return super(ResPartnerConsent, self).write(vals)
 
     def unlink(self):
+        """Block deletion of consent records by non-superuser calls.
+
+        Consent events must stay in the log permanently to preserve
+        the audit trail required for privacy compliance.
+
+        :raises UserError: when called without ``self.env.su``
+        """
         if not self.env.su:
             raise UserError(
                 _(

--- a/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js
+++ b/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js
@@ -101,7 +101,11 @@ odoo.define("ssi_partner_data_privacy_consent.partner_consent_notice_tour", func
                 },
                 {
                     content: "Fill in Body",
-                    trigger: ".o_field_widget[name='body'] textarea",
+                    // The Text widget class is on the <textarea> element
+                    // itself (o_field_text o_field_widget ...), not on a
+                    // wrapping <div> -- unlike some other field widgets,
+                    // there is no nested textarea to descend into.
+                    trigger: ".o_field_widget[name='body']",
                     run: "text This is the tour privacy notice body.",
                 },
 

--- a/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js
+++ b/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js
@@ -1,0 +1,126 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_data_privacy_consent.partner_consent_notice_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block -- Flow 1 of the partner_consent_notice IK:
+    // "Open the Contacts > Configuration > Data Privacy > Privacy Notice
+    // menu."
+    function openConsentNoticeList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the Data Privacy menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_data_privacy_consent.menu_config_data_privacy"]',
+            },
+            {
+                content: "Open the Privacy Notice menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_data_privacy_consent.partner_consent_notice_menu"]',
+            },
+            {
+                content: "Privacy Notice list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Privacy Notice)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/partner_consent_notice/01-create.md
+    tour.register(
+        "ssi_partner_data_privacy_consent_partner_consent_notice_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // ── Flow 1 — Open the Privacy Notice menu.
+            openConsentNoticeList(),
+            [
+                // ── Flow 2 — Click the Create button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Flow 3 — Fill in the required fields (Name, Code).
+                {
+                    content: "Fill in Name",
+                    trigger: ".o_field_widget[name='name']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR CONSENT NOTICE Create",
+                },
+                {
+                    content: "Fill in Code",
+                    trigger: ".o_field_widget[name='code']",
+                    run: "text TOURCONSENTNOTICE01",
+                },
+
+                // ── Flow 4 — Open the Privacy Notice tab and fill in
+                // Version and Body (Effective Date keeps its default).
+                {
+                    content: "Open the Privacy Notice tab",
+                    trigger: 'a[href="#notice"]',
+                },
+                {
+                    content: "Fill in Version",
+                    trigger: ".o_field_widget[name='version']",
+                    run: "text 1.0",
+                },
+                {
+                    content: "Fill in Body",
+                    trigger: ".o_field_widget[name='body'] textarea",
+                    run: "text This is the tour privacy notice body.",
+                },
+
+                // ── Flow 6 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // ── Post-Condition — A new Privacy Notice record is
+                // created and appears in the Privacy Notice list.
+                {
+                    content: "Record is saved and displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(TOUR CONSENT NOTICE Create)",
+                    extra_trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js
+++ b/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js
@@ -86,10 +86,14 @@ odoo.define("ssi_partner_data_privacy_consent.partner_consent_notice_tour", func
 
                 // ── Flow 4 — Open the Privacy Notice tab and fill in
                 // Version and Body (Effective Date keeps its default).
-                {
-                    content: "Open the Privacy Notice tab",
-                    trigger: 'a[href="#notice"]',
-                },
+                // "Privacy Notice" is the first page inserted into the
+                // master_data form notebook (xpath position="before" the
+                // "note" page), so it is already the active tab when the
+                // form opens -- no click needed. Odoo 14 also renders the
+                // tab's href as an auto-generated id (e.g. "#notebook_page_
+                // 774") rather than the page name, so a selector like
+                // `a[href="#notice"]` would never match even if a click
+                // were required.
                 {
                     content: "Fill in Version",
                     trigger: ".o_field_widget[name='version']",

--- a/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js
+++ b/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js
@@ -24,11 +24,10 @@ odoo.define("ssi_partner_data_privacy_consent.partner_consent_notice_tour", func
                 trigger:
                     '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
             },
-            {
-                content: "Open the Data Privacy menu",
-                trigger:
-                    '.o_menu_sections [data-menu-xmlid="ssi_partner_data_privacy_consent.menu_config_data_privacy"]',
-            },
+            // "Data Privacy" (menu_config_data_privacy) is a <menuitem>
+            // without an action that has children -- Odoo 14 renders it as
+            // a dropdown-header grouping label, not a clickable
+            // data-menu-xmlid item. Skip straight to the leaf menu below it.
             {
                 content: "Open the Privacy Notice menu",
                 trigger:

--- a/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_purpose_tour.js
+++ b/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_purpose_tour.js
@@ -24,11 +24,10 @@ odoo.define("ssi_partner_data_privacy_consent.partner_consent_purpose_tour", fun
                 trigger:
                     '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
             },
-            {
-                content: "Open the Data Privacy menu",
-                trigger:
-                    '.o_menu_sections [data-menu-xmlid="ssi_partner_data_privacy_consent.menu_config_data_privacy"]',
-            },
+            // "Data Privacy" (menu_config_data_privacy) is a <menuitem>
+            // without an action that has children -- Odoo 14 renders it as
+            // a dropdown-header grouping label, not a clickable
+            // data-menu-xmlid item. Skip straight to the leaf menu below it.
             {
                 content: "Open the Consent Purpose menu",
                 trigger:

--- a/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_purpose_tour.js
+++ b/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_purpose_tour.js
@@ -1,0 +1,109 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_data_privacy_consent.partner_consent_purpose_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block -- Flow 1 of the partner_consent_purpose IK:
+    // "Open the Contacts > Configuration > Data Privacy > Consent Purpose
+    // menu."
+    function openConsentPurposeList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the Data Privacy menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_data_privacy_consent.menu_config_data_privacy"]',
+            },
+            {
+                content: "Open the Consent Purpose menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_data_privacy_consent.partner_consent_purpose_menu"]',
+            },
+            {
+                content: "Consent Purpose list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Consent Purpose)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/partner_consent_purpose/01-create.md
+    tour.register(
+        "ssi_partner_data_privacy_consent_partner_consent_purpose_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // ── Flow 1 — Open the Consent Purpose menu.
+            openConsentPurposeList(),
+            [
+                // ── Flow 2 — Click the Create button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Flow 3 — Fill in the required fields (Name, Code).
+                {
+                    content: "Fill in Name",
+                    trigger: ".o_field_widget[name='name']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR CONSENT PURPOSE Create",
+                },
+                {
+                    content: "Fill in Code",
+                    trigger: ".o_field_widget[name='code']",
+                    run: "text TOURCONSENTPURPOSE01",
+                },
+
+                // ── Flow 5 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // ── Post-Condition — A new Consent Purpose record is
+                // created and appears in the Consent Purpose list.
+                {
+                    content: "Record is saved and displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(TOUR CONSENT PURPOSE Create)",
+                    extra_trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_partner_data_privacy_consent/tests/__init__.py
+++ b/ssi_partner_data_privacy_consent/tests/__init__.py
@@ -3,3 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_data_privacy_consent  # noqa: F401
+from . import test_ui_partner_consent_purpose  # noqa: F401
+from . import test_ui_partner_consent_notice  # noqa: F401

--- a/ssi_partner_data_privacy_consent/tests/test_data_privacy_consent.py
+++ b/ssi_partner_data_privacy_consent/tests/test_data_privacy_consent.py
@@ -9,5 +9,14 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestDataPrivacyConsent(YamlTransactionCase):
+    """Cover ``res.partner.consent`` and its related master data models.
+
+    Exercises purpose/notice master data CRUD, ACL for the
+    configurator group, immutability of consent records, required
+    fields, and the derivation of ``active_consent_purpose_ids`` on
+    ``res.partner`` from the consent log.
+    """
+
     def test_data_privacy_consent(self):
+        """Run the data privacy consent YAML scenario."""
         self.run_yaml_scenario("test_data_privacy_consent.yaml")

--- a/ssi_partner_data_privacy_consent/tests/test_ui_partner_consent_notice.py
+++ b/ssi_partner_data_privacy_consent/tests/test_ui_partner_consent_notice.py
@@ -1,0 +1,47 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPartnerConsentNotice(HttpSavepointCase):
+    """UI/UX tour test for the ``partner_consent_notice`` work instruction.
+
+    ``test_create`` runs the tour paired with the IK file named in its
+    docstring (``docs/partner_consent_notice/01-create.md``).
+    Pre-Condition data of that IK file is prepared here in Python --
+    never through UI steps -- so the tour only walks the click-flow the
+    IK documents.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Prepare the IK Pre-Condition for the create tour.
+
+        Covers ``Access``: admin is put in the *Partner Consent Privacy
+        Notice* group so the menu and Create button are visible.
+        """
+        super().setUpClass()
+
+        cls.user_admin = cls.env.ref("base.user_admin")
+        cls.group_notice = cls.env.ref(
+            "ssi_partner_data_privacy_consent.partner_consent_notice_group"
+        )
+        cls.group_notice.sudo().write(
+            {
+                "users": [(4, cls.user_admin.id)],
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``partner_consent_notice``.
+
+        IK: docs/partner_consent_notice/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_data_privacy_consent_partner_consent_notice_create",
+            login="admin",
+        )

--- a/ssi_partner_data_privacy_consent/tests/test_ui_partner_consent_purpose.py
+++ b/ssi_partner_data_privacy_consent/tests/test_ui_partner_consent_purpose.py
@@ -1,0 +1,47 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPartnerConsentPurpose(HttpSavepointCase):
+    """UI/UX tour test for the ``partner_consent_purpose`` work instruction.
+
+    ``test_create`` runs the tour paired with the IK file named in its
+    docstring (``docs/partner_consent_purpose/01-create.md``).
+    Pre-Condition data of that IK file is prepared here in Python --
+    never through UI steps -- so the tour only walks the click-flow the
+    IK documents.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Prepare the IK Pre-Condition for the create tour.
+
+        Covers ``Access``: admin is put in the *Partner Consent
+        Purpose* group so the menu and Create button are visible.
+        """
+        super().setUpClass()
+
+        cls.user_admin = cls.env.ref("base.user_admin")
+        cls.group_purpose = cls.env.ref(
+            "ssi_partner_data_privacy_consent.partner_consent_purpose_group"
+        )
+        cls.group_purpose.sudo().write(
+            {
+                "users": [(4, cls.user_admin.id)],
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``partner_consent_purpose``.
+
+        IK: docs/partner_consent_purpose/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_data_privacy_consent_partner_consent_purpose_create",
+            login="admin",
+        )

--- a/ssi_partner_data_privacy_consent/views/assets.xml
+++ b/ssi_partner_data_privacy_consent/views/assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_partner_data_privacy_consent assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_purpose_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_partner_data_privacy_consent/static/tests/tours/partner_consent_notice_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memenuhi validator kepatuhan (`module`, `ik`, `unit-test`) di modul
`ssi_partner_data_privacy_consent` sesuai temuan sapuan `audit-sweep.sh 14.0`
tanpa mengubah perilaku fungsional.

* Tambah docstring pada seluruh class/method yang belum berdocstring:
  `ResPartner`, `_compute_active_consent_purpose_ids`, `write`/`unlink` pada
  `res.partner.consent`, class dan method test.
* Tambah Instruksi Kerja (IK) di `docs/` untuk `partner_consent_purpose` dan
  `partner_consent_notice` (create, edit, delete, deactivate, activate).
* Tambah tour UI (`web_tour`) create untuk kedua model tersebut, dipetakan
  1:1 dari Flow IK-nya, beserta `HttpCase` Python-nya.
* Sinkronkan `README.rst` dengan entri Work Instruction yang baru.

`res.partner.consent` (log konsen, readonly, tanpa aksi CRUD via UI) dan
`res.partner` (hanya menambah tab informasional read-only) tidak mendapat IK
tersendiri sesuai doktrin `odoo-development-instruksi-kerja` — IK hanya
dibuat untuk model yang bisa berdiri sendiri dan tab read-only tidak
memenuhi syarat E1.

## Bukti validator (setelah perubahan)

```
#VALIDATOR name=module    target=ssi_partner_data_privacy_consent series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik        target=ssi_partner_data_privacy_consent series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_partner_data_privacy_consent series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour      target=ssi_partner_data_privacy_consent series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-partner modules=1 failed=0 skipped=0 status=OK
```

Closes #74