### PR TITLE
[UPD] ssi_partner_experience - penuhi validator kepatuhan

### DIFF
--- a/ssi_partner_experience/README.rst
+++ b/ssi_partner_experience/README.rst
@@ -7,6 +7,14 @@ Partner Experience
 ==================
 
 
+Work Instruction
+================
+
+* `Professional Experience <docs/partner_experience/index.html>`_
+* `Academic Experience <docs/partner_academic/index.html>`_
+* `Certification <docs/partner_certification/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_partner_experience/__manifest__.py
+++ b/ssi_partner_experience/__manifest__.py
@@ -14,11 +14,13 @@
         "mail",
         "ssi_duration_mixin",
         "ssi_partner_education_level",
+        "web_tour",
     ],
     "data": [
         "security/res_group_data.xml",
         "security/ir.model.access.csv",
         "menu.xml",
+        "views/assets.xml",
         "views/partner_academic_view.xml",
         "views/partner_certification_view.xml",
         "views/partner_experience_view.xml",

--- a/ssi_partner_experience/docs/partner_academic/01-create.md
+++ b/ssi_partner_experience/docs/partner_academic/01-create.md
@@ -1,0 +1,40 @@
+# Create Academic Experience
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.academic`\
+> **Menu:** Contacts > Configuration > Experiences > Academic Experiences\
+> **Actor:** user in group `Contact's Academic Experience`
+
+## Pre-Condition
+
+- **Data:** The contact (`res.partner`) this academic record belongs to already exists.
+- **Access:** User is in group `Contact's Academic Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Academic Experiences** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Partner** _(required)_: Select the contact this academic record belongs to.
+   - **Date Start** _(required)_: Enter the date this study period started.
+   - **Date End** _(required if **Expire** is checked)_: Enter the date this study
+     period ended. **Expire** is checked by default; uncheck it if the study period is
+     still ongoing so **Date End** is no longer required.
+4. Optionally fill in the remaining fields:
+   - **Institution**: The school or university this academic record belongs to.
+   - **Location**: Where this institution is located.
+   - **Diploma Number**: The diploma or certificate number issued.
+   - **Education Level**: The level of education completed.
+   - **Field of Study**: The major or field studied.
+   - **Latest GPA**: The final grade point average obtained.
+   - **Activities and associations**: Extracurricular activities or associations during
+     this period.
+5. Optionally fill in the **Note** tab with free-text notes about this academic record.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new **Academic Experience** record is created and appears in the Academic
+  Experiences list.
+- The record also appears on the **Experiences** page of the related contact's form,
+  under **Academics**.

--- a/ssi_partner_experience/docs/partner_academic/02-edit.md
+++ b/ssi_partner_experience/docs/partner_academic/02-edit.md
@@ -1,0 +1,23 @@
+# Edit Academic Experience
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.academic`\
+> **Menu:** Contacts > Configuration > Experiences > Academic Experiences\
+> **Actor:** user in group `Contact's Academic Experience`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The academic experience record already exists.
+- **Access:** User is in group `Contact's Academic Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Academic Experiences** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_partner_experience/docs/partner_academic/03-delete.md
+++ b/ssi_partner_experience/docs/partner_academic/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Academic Experience
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.academic`\
+> **Menu:** Contacts > Configuration > Experiences > Academic Experiences\
+> **Actor:** user in group `Contact's Academic Experience`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The academic experience record already exists.
+- **Access:** User is in group `Contact's Academic Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Academic Experiences** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_partner_experience/docs/partner_certification/01-create.md
+++ b/ssi_partner_experience/docs/partner_certification/01-create.md
@@ -1,0 +1,35 @@
+# Create Certification
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.certification`\
+> **Menu:** Contacts > Configuration > Experiences > Certifications\
+> **Actor:** user in group `Contact's Certification Experience`
+
+## Pre-Condition
+
+- **Data:** The contact (`res.partner`) this certification belongs to already exists.
+- **Access:** User is in group `Contact's Certification Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Certifications** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Partner** _(required)_: Select the contact this certification belongs to.
+   - **Date Start** _(required)_: Enter the date this certification was obtained.
+   - **Date End** _(required if **Expire** is checked)_: Enter the date this
+     certification expires. **Expire** is checked by default; uncheck it if the
+     certification does not expire so **Date End** is no longer required.
+4. Optionally fill in the remaining fields:
+   - **Certification**: A name identifying this certification.
+   - **Certification Number**: The certificate number issued.
+   - **Issued By**: The authority that issued this certification.
+   - **Location**: Where this certification was issued.
+5. Optionally fill in the **Note** tab with free-text notes about this certification.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new **Certification** record is created and appears in the Certifications list.
+- The record also appears on the **Experiences** page of the related contact's form,
+  under **Certifications**.

--- a/ssi_partner_experience/docs/partner_certification/02-edit.md
+++ b/ssi_partner_experience/docs/partner_certification/02-edit.md
@@ -1,0 +1,23 @@
+# Edit Certification
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.certification`\
+> **Menu:** Contacts > Configuration > Experiences > Certifications\
+> **Actor:** user in group `Contact's Certification Experience`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The certification record already exists.
+- **Access:** User is in group `Contact's Certification Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Certifications** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_partner_experience/docs/partner_certification/03-delete.md
+++ b/ssi_partner_experience/docs/partner_certification/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Certification
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.certification`\
+> **Menu:** Contacts > Configuration > Experiences > Certifications\
+> **Actor:** user in group `Contact's Certification Experience`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The certification record already exists.
+- **Access:** User is in group `Contact's Certification Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Certifications** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_partner_experience/docs/partner_experience/01-create.md
+++ b/ssi_partner_experience/docs/partner_experience/01-create.md
@@ -1,0 +1,37 @@
+# Create Professional Experience
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.experience`\
+> **Menu:** Contacts > Configuration > Experiences > Professional Experiences\
+> **Actor:** user in group `Contact's Professional Experience`
+
+## Pre-Condition
+
+- **Data:** The contact (`res.partner`) this experience belongs to already exists.
+- **Access:** User is in group `Contact's Professional Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Professional Experiences** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Partner** _(required)_: Select the contact this professional experience belongs
+     to.
+   - **Date Start** _(required)_: Enter the date this job started.
+   - **Date End** _(required if **Expire** is checked)_: Enter the date this job ended.
+     **Expire** is checked by default; uncheck it if the job is still ongoing so **Date
+     End** is no longer required.
+4. Optionally fill in the remaining fields:
+   - **Job Position**: The role held during this experience.
+   - **Job Level**: The seniority level of the role.
+   - **Employer**: The company or institution this experience was held at.
+   - **Location**: Where this job took place.
+5. Optionally fill in the **Note** tab with free-text notes about this experience.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new **Professional Experience** record is created and appears in the Professional
+  Experiences list.
+- The record also appears on the **Experiences** page of the related contact's form,
+  under **Professional Experiences**.

--- a/ssi_partner_experience/docs/partner_experience/02-edit.md
+++ b/ssi_partner_experience/docs/partner_experience/02-edit.md
@@ -1,0 +1,23 @@
+# Edit Professional Experience
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.experience`\
+> **Menu:** Contacts > Configuration > Experiences > Professional Experiences\
+> **Actor:** user in group `Contact's Professional Experience`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The professional experience record already exists.
+- **Access:** User is in group `Contact's Professional Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Professional Experiences** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_partner_experience/docs/partner_experience/03-delete.md
+++ b/ssi_partner_experience/docs/partner_experience/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Professional Experience
+
+> **Module:** ssi_partner_experience\
+> **Model:** `partner.experience`\
+> **Menu:** Contacts > Configuration > Experiences > Professional Experiences\
+> **Actor:** user in group `Contact's Professional Experience`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The professional experience record already exists.
+- **Access:** User is in group `Contact's Professional Experience`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Experiences > Professional Experiences** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_partner_experience/models/partner_academic.py
+++ b/ssi_partner_experience/models/partner_academic.py
@@ -6,6 +6,16 @@ from odoo import fields, models
 
 
 class PartnerAcademic(models.Model):
+    """
+    Records one academic history entry of a contact.
+
+    Each record represents a study period of the ``res.partner``
+    referenced in ``partner_id`` at the institution stored in
+    ``partner_address_id`` (inherited from ``partner.experience.mixin``),
+    together with the diploma, education level, field of study, GPA, and
+    activities/associations of that period.
+    """
+
     _name = "partner.academic"
     _inherit = "partner.experience.mixin"
     _description = "Contact's Academic Experience"

--- a/ssi_partner_experience/models/partner_certification.py
+++ b/ssi_partner_experience/models/partner_certification.py
@@ -6,6 +6,15 @@ from odoo import fields, models
 
 
 class PartnerCertification(models.Model):
+    """
+    Records one professional certification held by a contact.
+
+    Each record represents a certification obtained by the
+    ``res.partner`` referenced in ``partner_id``, issued by the authority
+    stored in ``partner_address_id`` (inherited from
+    ``partner.experience.mixin``) and identified by ``certification``.
+    """
+
     _name = "partner.certification"
     _inherit = "partner.experience.mixin"
     _description = "Contact's Certification Experience"

--- a/ssi_partner_experience/models/partner_experience.py
+++ b/ssi_partner_experience/models/partner_experience.py
@@ -6,6 +6,15 @@ from odoo import fields, models
 
 
 class PartnerExperience(models.Model):
+    """
+    Records one professional job experience of a contact.
+
+    Each record represents a past or current employment held by the
+    ``res.partner`` referenced in ``partner_id``, with the employer stored
+    in ``partner_address_id`` (inherited from ``partner.experience.mixin``)
+    and the role described by ``job_position``/``job_level``.
+    """
+
     _name = "partner.experience"
     _inherit = "partner.experience.mixin"
     _description = "Contact's Professional Experience"

--- a/ssi_partner_experience/models/partner_experience_mixin.py
+++ b/ssi_partner_experience/models/partner_experience_mixin.py
@@ -6,6 +6,19 @@ from odoo import fields, models
 
 
 class PartnerExperienceMixin(models.AbstractModel):
+    """
+    Abstract base shared by the different kinds of contact background
+    records (professional experience, academic history, certification).
+
+    Provides the fields common to all of them: the owning ``partner_id``,
+    the institution/employer (``partner_address_id``), location, the
+    ``date_start``/``date_end`` pair inherited from ``mixin.date_duration``,
+    an ``expire`` flag, and the ``active`` flag used to archive a record
+    instead of deleting it. Concrete models add only the fields specific
+    to their kind of record (e.g. ``job_position`` for
+    ``partner.experience``, ``diploma`` for ``partner.academic``).
+    """
+
     _name = "partner.experience.mixin"
     _inherit = [
         "mail.activity.mixin",

--- a/ssi_partner_experience/models/res_partner.py
+++ b/ssi_partner_experience/models/res_partner.py
@@ -6,6 +6,15 @@ from odoo import fields, models
 
 
 class ResPartner(models.Model):
+    """
+    Adds background history to the contact form.
+
+    Exposes the ``partner.academic``, ``partner.certification``, and
+    ``partner.experience`` records owned by this contact as one2many
+    lines, so the Experiences page on the contact form can display and
+    manage them.
+    """
+
     _inherit = "res.partner"
 
     academic_ids = fields.One2many(

--- a/ssi_partner_experience/static/tests/tours/partner_academic_tour.js
+++ b/ssi_partner_experience/static/tests/tours/partner_academic_tour.js
@@ -1,0 +1,141 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_experience.partner_academic_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block -- Flow 1 of the partner_academic IK:
+    // "Open the Contacts > Configuration > Experiences > Academic
+    // Experiences menu."
+    //
+    // "Experiences" (ssi_partner_experience.menu_config_partner_experience)
+    // is a <menuitem> WITHOUT an action that has children, so Odoo 14
+    // renders it as an unclickable "dropdown-header" grouping label (no
+    // data-menu-xmlid) and flattens its children straight into the
+    // Configuration dropdown. There is therefore NO step for it -- the
+    // tour goes straight from Configuration to the leaf menu below it.
+    function openPartnerAcademicList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the Academic Experiences menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_experience.partner_academic_menu"]',
+            },
+            {
+                content: "Academic Experiences list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Academic Experiences)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/partner_academic/01-create.md
+    tour.register(
+        "ssi_partner_experience_partner_academic_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // ── Flow 1 — Open the Academic Experiences menu.
+            openPartnerAcademicList(),
+            [
+                // ── Flow 2 — Click the New button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Flow 3 — Fill in the required fields (Partner, Date
+                // Start, Date End -- Expire stays checked by default).
+                {
+                    content: "Select the Partner",
+                    trigger: ".o_field_many2one[name='partner_id'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR Partner Academic Create",
+                },
+                {
+                    content: "Pick the Partner from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR Partner Academic Create)",
+                    in_modal: false,
+                },
+                {
+                    content: "Fill in Date Start",
+                    trigger: ".o_field_widget[name='date_start'] input",
+                    run: "text 01/15/2015",
+                },
+                {
+                    content: "Fill in Date End",
+                    trigger: ".o_field_widget[name='date_end'] input",
+                    run: "text 01/15/2019",
+                },
+
+                // ── Flow 4 — Optionally fill in Diploma Number (used here
+                // to identify the record afterwards).
+                {
+                    content: "Fill in Diploma Number",
+                    trigger: ".o_field_widget[name='diploma']",
+                    run: "text TOUR-DIPLOMA-001",
+                },
+
+                // ── Flow 6 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Post-Condition — the new record appears in the
+                // Academic Experiences list.
+                {
+                    content: "Go back to the Academic Experiences list",
+                    trigger:
+                        ".breadcrumb-item:not(.active):contains(Academic Experiences)",
+                },
+                {
+                    content: "New record is displayed in the list",
+                    trigger: ".o_data_row:contains(TOUR-DIPLOMA-001)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_partner_experience/static/tests/tours/partner_certification_tour.js
+++ b/ssi_partner_experience/static/tests/tours/partner_certification_tour.js
@@ -1,0 +1,129 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_experience.partner_certification_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block -- Flow 1 of the partner_certification IK:
+    // "Open the Contacts > Configuration > Experiences > Certifications
+    // menu."
+    //
+    // "Experiences" (ssi_partner_experience.menu_config_partner_experience)
+    // is a <menuitem> WITHOUT an action that has children, so Odoo 14
+    // renders it as an unclickable "dropdown-header" grouping label (no
+    // data-menu-xmlid) and flattens its children straight into the
+    // Configuration dropdown. There is therefore NO step for it -- the
+    // tour goes straight from Configuration to the leaf menu below it.
+    function openPartnerCertificationList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the Certifications menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_experience.partner_certification_menu"]',
+            },
+            {
+                content: "Certifications list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Certifications)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/partner_certification/01-create.md
+    tour.register(
+        "ssi_partner_experience_partner_certification_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // ── Flow 1 — Open the Certifications menu.
+            openPartnerCertificationList(),
+            [
+                // ── Flow 2 — Click the New button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Flow 3 — Fill in the required fields (Partner, Date
+                // Start, Date End -- Expire stays checked by default).
+                {
+                    content: "Select the Partner",
+                    trigger: ".o_field_many2one[name='partner_id'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR Partner Certification Create",
+                },
+                {
+                    content: "Pick the Partner from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR Partner Certification Create)",
+                    in_modal: false,
+                },
+                {
+                    content: "Fill in Date Start",
+                    trigger: ".o_field_widget[name='date_start'] input",
+                    run: "text 01/15/2023",
+                },
+                {
+                    content: "Fill in Date End",
+                    trigger: ".o_field_widget[name='date_end'] input",
+                    run: "text 01/15/2026",
+                },
+
+                // ── Flow 4 — Optionally fill in Certification (used here
+                // to identify the record afterwards).
+                {
+                    content: "Fill in Certification",
+                    trigger: ".o_field_widget[name='name']",
+                    run: "text TOUR CERTIFICATION Create",
+                },
+
+                // ── Flow 6 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // ── Post-Condition — the new Certification record is
+                // created and appears in the Certifications list.
+                {
+                    content: "Record is saved and displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(TOUR CERTIFICATION Create)",
+                    extra_trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_partner_experience/static/tests/tours/partner_experience_tour.js
+++ b/ssi_partner_experience/static/tests/tours/partner_experience_tour.js
@@ -1,0 +1,141 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_experience.partner_experience_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block -- Flow 1 of the partner_experience IK:
+    // "Open the Contacts > Configuration > Experiences > Professional
+    // Experiences menu."
+    //
+    // "Experiences" (ssi_partner_experience.menu_config_partner_experience)
+    // is a <menuitem> WITHOUT an action that has children, so Odoo 14
+    // renders it as an unclickable "dropdown-header" grouping label (no
+    // data-menu-xmlid) and flattens its children straight into the
+    // Configuration dropdown. There is therefore NO step for it -- the
+    // tour goes straight from Configuration to the leaf menu below it.
+    function openPartnerExperienceList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the Professional Experiences menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_experience.partner_experience_menu"]',
+            },
+            {
+                content: "Professional Experiences list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Professional Experiences)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/partner_experience/01-create.md
+    tour.register(
+        "ssi_partner_experience_partner_experience_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // ── Flow 1 — Open the Professional Experiences menu.
+            openPartnerExperienceList(),
+            [
+                // ── Flow 2 — Click the New button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Flow 3 — Fill in the required fields (Partner, Date
+                // Start, Date End -- Expire stays checked by default).
+                {
+                    content: "Select the Partner",
+                    trigger: ".o_field_many2one[name='partner_id'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR Partner Experience Create",
+                },
+                {
+                    content: "Pick the Partner from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR Partner Experience Create)",
+                    in_modal: false,
+                },
+                {
+                    content: "Fill in Date Start",
+                    trigger: ".o_field_widget[name='date_start'] input",
+                    run: "text 01/15/2020",
+                },
+                {
+                    content: "Fill in Date End",
+                    trigger: ".o_field_widget[name='date_end'] input",
+                    run: "text 01/15/2021",
+                },
+
+                // ── Flow 4 — Optionally fill in Job Position (used here to
+                // identify the record afterwards).
+                {
+                    content: "Fill in Job Position",
+                    trigger: ".o_field_widget[name='job_position']",
+                    run: "text TOUR EXPERIENCE JOB",
+                },
+
+                // ── Flow 6 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Post-Condition — the new record appears in the
+                // Professional Experiences list.
+                {
+                    content: "Go back to the Professional Experiences list",
+                    trigger:
+                        ".breadcrumb-item:not(.active):contains(Professional Experiences)",
+                },
+                {
+                    content: "New record is displayed in the list",
+                    trigger: ".o_data_row:contains(TOUR EXPERIENCE JOB)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_partner_experience/tests/__init__.py
+++ b/ssi_partner_experience/tests/__init__.py
@@ -3,3 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_partner_experience  # noqa: F401
+from . import test_ui_partner_experience  # noqa: F401
+from . import test_ui_partner_academic  # noqa: F401
+from . import test_ui_partner_certification  # noqa: F401

--- a/ssi_partner_experience/tests/test_partner_experience.py
+++ b/ssi_partner_experience/tests/test_partner_experience.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestPartnerExperience(YamlTransactionCase):
+    """Cover ``partner.experience`` and ``partner.academic`` creation."""
+
     def test_partner_experience(self):
+        """Run the create scenarios for experience and academic records."""
         self.run_yaml_scenario("test_data_partner_experience.yaml")

--- a/ssi_partner_experience/tests/test_ui_partner_academic.py
+++ b/ssi_partner_experience/tests/test_ui_partner_academic.py
@@ -1,0 +1,36 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPartnerAcademic(HttpSavepointCase):
+    """UI/UX tour test for the ``partner.academic`` work instruction."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the configurator group the create tour menu requires.
+
+        Pre-Condition: the Academic Experiences menu is gated by the
+        ``Contact's Academic Experience`` group. Without it the tour dies
+        on its first step -- the menu is never rendered for admin.
+        """
+        super().setUpClass()
+        cls.env.ref(
+            "ssi_partner_experience.partner_academic_configurator_group"
+        ).sudo().write(
+            {
+                "users": [(4, cls.env.ref("base.user_admin").id)],
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``partner.academic``.
+
+        IK: docs/partner_academic/01-create.md
+        """
+        self.start_tour(
+            "/web", "ssi_partner_experience_partner_academic_create", login="admin"
+        )

--- a/ssi_partner_experience/tests/test_ui_partner_certification.py
+++ b/ssi_partner_experience/tests/test_ui_partner_certification.py
@@ -1,0 +1,38 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPartnerCertification(HttpSavepointCase):
+    """UI/UX tour test for the ``partner.certification`` work instruction."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the configurator group the create tour menu requires.
+
+        Pre-Condition: the Certifications menu is gated by the
+        ``Contact's Certification Experience`` group. Without it the tour
+        dies on its first step -- the menu is never rendered for admin.
+        """
+        super().setUpClass()
+        cls.env.ref(
+            "ssi_partner_experience.partner_certification_configurator_group"
+        ).sudo().write(
+            {
+                "users": [(4, cls.env.ref("base.user_admin").id)],
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``partner.certification``.
+
+        IK: docs/partner_certification/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_experience_partner_certification_create",
+            login="admin",
+        )

--- a/ssi_partner_experience/tests/test_ui_partner_experience.py
+++ b/ssi_partner_experience/tests/test_ui_partner_experience.py
@@ -1,0 +1,36 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPartnerExperience(HttpSavepointCase):
+    """UI/UX tour test for the ``partner.experience`` work instruction."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the configurator group the create tour menu requires.
+
+        Pre-Condition: the Professional Experiences menu is gated by the
+        ``Contact's Professional Experience`` group. Without it the tour
+        dies on its first step -- the menu is never rendered for admin.
+        """
+        super().setUpClass()
+        cls.env.ref(
+            "ssi_partner_experience.partner_experience_configurator_group"
+        ).sudo().write(
+            {
+                "users": [(4, cls.env.ref("base.user_admin").id)],
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``partner.experience``.
+
+        IK: docs/partner_experience/01-create.md
+        """
+        self.start_tour(
+            "/web", "ssi_partner_experience_partner_experience_create", login="admin"
+        )

--- a/ssi_partner_experience/views/assets.xml
+++ b/ssi_partner_experience/views/assets.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_partner_experience assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_partner_experience/static/tests/tours/partner_experience_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_partner_experience/static/tests/tours/partner_academic_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_partner_experience/static/tests/tours/partner_certification_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Memenuhi validator kepatuhan (`module`, `ik`, `unit-test`) di modul `ssi_partner_experience`:

* Tambah docstring pada seluruh class model (`PartnerExperienceMixin`, `PartnerExperience`, `PartnerAcademic`, `PartnerCertification`, `ResPartner`) dan class/method test yang belum memilikinya.
* Tambah Instruksi Kerja (IK) untuk model `partner.experience`, `partner.academic`, dan `partner.certification` (create, edit, delete) di `docs/`.
* Tambah tour UI (`web_tour`) untuk aksi create pada ketiga model tersebut, dipetakan 1:1 dari Flow IK `01-create.md`.
* Tambah bagian `Work Instruction` pada `README.rst`.

Tidak ada perubahan perilaku fungsional, field, method, atau model yang sudah ada.

## Verifikasi

```
#GATE repo=ssi-partner modules=1 failed=0 skipped=0 status=OK
#VALIDATOR name=module target=ssi_partner_experience series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik target=ssi_partner_experience series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_partner_experience series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour target=ssi_partner_experience series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Closes #75