### PR TITLE
[UPD] ssi_partner_education_level - Kepatuhan validator (docstring, IK, tour)

### DIFF
--- a/ssi_partner_education_level/README.rst
+++ b/ssi_partner_education_level/README.rst
@@ -19,6 +19,12 @@ To install this module, you need to:
 5.  Search For *Partner Education Level*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Create Field of Study <docs/partner_field_of_study/index.html>`_
+* `Create Formal Education Level <docs/partner_formal_education_level/index.html>`_
+
 Bug Tracker
 ===========
 

--- a/ssi_partner_education_level/__manifest__.py
+++ b/ssi_partner_education_level/__manifest__.py
@@ -13,11 +13,13 @@
     "depends": [
         "ssi_master_data_mixin",
         "ssi_partner",
+        "web_tour",
     ],
     "data": [
         "security/res_group_data.xml",
         "security/ir.model.access.csv",
         "menu.xml",
+        "views/assets.xml",
         "views/partner_field_of_study_views.xml",
         "views/partner_formal_education_level_views.xml",
         "views/res_partner_view.xml",

--- a/ssi_partner_education_level/docs/partner_field_of_study/01-create.md
+++ b/ssi_partner_education_level/docs/partner_field_of_study/01-create.md
@@ -1,0 +1,26 @@
+# Create Field of Study
+
+> **Module:** ssi_partner_education_level\
+> **Model:** `partner.field_of_study`\
+> **Menu:** Contacts > Configuration > Education Levels > Field of Study\
+> **Actor:** user in group `Field Of Study`
+
+## Pre-Condition
+
+- None.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Education Levels > Field of Study** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name**: Enter the field of study name.
+   - **Code**: Enter a unique code for this field of study, or fill with **/** to
+     generate it later using the **Generate Code** button.
+   - **Parent**: Optionally select a parent field of study to build a hierarchy.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new Field of Study record is created and available for selection as **Latest Field
+  of Study** on a partner.

--- a/ssi_partner_education_level/docs/partner_formal_education_level/01-create.md
+++ b/ssi_partner_education_level/docs/partner_formal_education_level/01-create.md
@@ -1,0 +1,27 @@
+# Create Formal Education Level
+
+> **Module:** ssi_partner_education_level\
+> **Model:** `partner.formal_education_level`\
+> **Menu:** Contacts > Configuration > Education Levels > Education Level\
+> **Actor:** user in group `Formal Education Level`
+
+## Pre-Condition
+
+- None.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Education Levels > Education Level** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name**: Enter the formal education level name.
+   - **Code**: Enter a unique code for this education level, or fill with **/** to
+     generate it later using the **Generate Code** button.
+   - **Sequence**: Defaults to **5**. Optionally change it to control the display order
+     among other education levels.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new Formal Education Level record is created and available for selection as **Latest
+  Formal Level Education** on a partner.

--- a/ssi_partner_education_level/models/partner_field_of_study.py
+++ b/ssi_partner_education_level/models/partner_field_of_study.py
@@ -6,6 +6,12 @@ from odoo import fields, models
 
 
 class PartnerFieldOfStudy(models.Model):
+    """
+    Represents a field of study (academic major) master data record.
+    Used to classify the education background of a partner, and can be
+    organized hierarchically through ``parent_id``/``child_ids``.
+    """
+
     _name = "partner.field_of_study"
     _inherit = ["mixin.master_data"]
     _description = "Field of Study"

--- a/ssi_partner_education_level/models/partner_formal_education_level.py
+++ b/ssi_partner_education_level/models/partner_formal_education_level.py
@@ -6,6 +6,12 @@ from odoo import fields, models
 
 
 class PartnerFormalEducationLevel(models.Model):
+    """
+    Represents a formal education level master data record (e.g. High
+    School, Bachelor, Master). Used to classify the highest formal
+    education attained by a partner, ordered by ``sequence``.
+    """
+
     _name = "partner.formal_education_level"
     _inherit = ["mixin.master_data"]
     _description = "Formal Education Level"

--- a/ssi_partner_education_level/models/res_partner.py
+++ b/ssi_partner_education_level/models/res_partner.py
@@ -6,6 +6,13 @@ from odoo import fields, models
 
 
 class ResPartner(models.Model):
+    """
+    Adds latest formal education information to the partner.
+    Stores the partner's latest formal education level, field of
+    study, education institution, GPA, and diploma, all visible on
+    the individual (non-company) partner form.
+    """
+
     _inherit = "res.partner"
 
     formal_education_level_id = fields.Many2one(

--- a/ssi_partner_education_level/static/tests/tours/partner_field_of_study_tour.js
+++ b/ssi_partner_education_level/static/tests/tours/partner_field_of_study_tour.js
@@ -1,0 +1,98 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_education_level.partner_field_of_study_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/partner_field_of_study/01-create.md
+    tour.register(
+        "ssi_partner_education_level_partner_field_of_study_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Flow 1 — Open the Contacts > Configuration > Education
+            // Levels > Field of Study menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            // "Education Levels" is a grouping menuitem WITHOUT an action
+            // (it only has children) -- Odoo 14.0 renders it as a
+            // non-clickable <div class="dropdown-header">, without
+            // data-menu-xmlid. Skip it and go straight to the leaf menu.
+            {
+                content: "Open the Field of Study menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_education_level.partner_field_of_study_menu"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang, bukan
+                // sekadar "ada list di layar" (patterns.md skill
+                // odoo-development-ui-test §A).
+                content: "Field of Study list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Field of Study)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Flow 3 — Fill in the required fields: Name, Code. Parent
+            // is optional and not needed to prove the create flow works.
+            {
+                content: "Fill in the Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Field Of Study",
+            },
+            {
+                content: "Fill in the Code",
+                trigger: ".o_field_widget[name='code']",
+                run: "text /",
+            },
+
+            // ── Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // ── Post-Condition — a new Field of Study record is created.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_partner_education_level/static/tests/tours/partner_formal_education_level_tour.js
+++ b/ssi_partner_education_level/static/tests/tours/partner_formal_education_level_tour.js
@@ -1,0 +1,101 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_partner_education_level.partner_formal_education_level_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/partner_formal_education_level/01-create.md
+        tour.register(
+            "ssi_partner_education_level_partner_formal_education_level_create",
+            {
+                test: true,
+                url: "/web",
+            },
+            [
+                // ── Flow 1 — Open the Contacts > Configuration >
+                // Education Levels > Education Level menu.
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Contacts app",
+                    trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+                },
+                {
+                    content: "Open the Configuration menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+                },
+                // "Education Levels" is a grouping menuitem WITHOUT an
+                // action (it only has children) -- Odoo 14.0 renders it
+                // as a non-clickable <div class="dropdown-header">,
+                // without data-menu-xmlid. Skip it and go straight to
+                // the leaf menu.
+                {
+                    content: "Open the Education Level menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_partner_education_level.partner_formal_education_level_menu"]',
+                },
+                {
+                    // Gerbang: tunggu action TUJUAN benar-benar
+                    // terpasang, bukan sekadar "ada list di layar"
+                    // (patterns.md skill odoo-development-ui-test §A).
+                    content: "Education Level list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Education Level)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // ── Flow 2 — Click the New button.
+                {
+                    content: "Click New",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // ── Flow 3 — Fill in the required fields: Name, Code.
+                // Sequence already carries its default value (5).
+                {
+                    content: "Fill in the Name",
+                    trigger: ".o_field_widget[name='name']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR Formal Education Level",
+                },
+                {
+                    content: "Fill in the Code",
+                    trigger: ".o_field_widget[name='code']",
+                    run: "text /",
+                },
+
+                // ── Flow 4 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // ── Post-Condition — a new Formal Education Level
+                // record is created.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_partner_education_level/tests/__init__.py
+++ b/ssi_partner_education_level/tests/__init__.py
@@ -3,3 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_education_level  # noqa: F401
+from . import test_ui_partner_field_of_study  # noqa: F401
+from . import test_ui_partner_formal_education_level  # noqa: F401

--- a/ssi_partner_education_level/tests/test_education_level.py
+++ b/ssi_partner_education_level/tests/test_education_level.py
@@ -9,5 +9,12 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestEducationLevel(YamlTransactionCase):
+    """Cover master data creation for education level models.
+
+    Exercises ``partner.formal_education_level`` and
+    ``partner.field_of_study`` record creation.
+    """
+
     def test_education_level(self):
+        """Run the education level master data creation scenario."""
         self.run_yaml_scenario("test_data_education_level.yaml")

--- a/ssi_partner_education_level/tests/test_ui_partner_field_of_study.py
+++ b/ssi_partner_education_level/tests/test_ui_partner_field_of_study.py
@@ -1,0 +1,28 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase -- NOT HttpCase. HttpCase in 14.0 inherits
+# TransactionCase, which does not set up ``cls.env`` in ``setUpClass``.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPartnerFieldOfStudy(HttpSavepointCase):
+    """UI/UX tour tests for ``partner.field_of_study``.
+
+    The ``test_create`` method below runs the tour pairing with the IK
+    file named in its docstring (``docs/partner_field_of_study/
+    01-create.md``).
+    """
+
+    def test_create(self):
+        """Run the create tour for ``partner.field_of_study``.
+
+        IK: docs/partner_field_of_study/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_education_level_partner_field_of_study_create",
+            login="admin",
+        )

--- a/ssi_partner_education_level/tests/test_ui_partner_formal_education_level.py
+++ b/ssi_partner_education_level/tests/test_ui_partner_formal_education_level.py
@@ -1,0 +1,28 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase -- NOT HttpCase. HttpCase in 14.0 inherits
+# TransactionCase, which does not set up ``cls.env`` in ``setUpClass``.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPartnerFormalEducationLevel(HttpSavepointCase):
+    """UI/UX tour tests for ``partner.formal_education_level``.
+
+    The ``test_create`` method below runs the tour pairing with the IK
+    file named in its docstring (``docs/partner_formal_education_level/
+    01-create.md``).
+    """
+
+    def test_create(self):
+        """Run the create tour for ``partner.formal_education_level``.
+
+        IK: docs/partner_formal_education_level/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_education_level_partner_formal_education_level_create",
+            login="admin",
+        )

--- a/ssi_partner_education_level/views/assets.xml
+++ b/ssi_partner_education_level/views/assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_partner_education_level assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_partner_education_level/static/tests/tours/partner_field_of_study_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_partner_education_level/static/tests/tours/partner_formal_education_level_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menuntaskan seluruh temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-partner`
pada modul `ssi_partner_education_level` (validator `module`, `ik`, `unit-test`), tanpa
mengubah perilaku fungsional apa pun.

- Tambahkan docstring pada seluruh class & method yang sebelumnya kosong (model
  `partner.field_of_study`, `partner.formal_education_level`, ekstensi `res.partner`,
  serta class/method test).
- Tambahkan direktori `docs/` berisi Instruksi Kerja (IK) create untuk
  `partner.field_of_study` dan `partner.formal_education_level` (modul ini sebelumnya
  belum punya `docs/` sama sekali).
- Tambahkan tour UI (Odoo Tour) pasangan tiap IK, beserta `HttpCase` pemanggilnya dan
  pendaftaran bundle `web.assets_tests`.
- Perbarui `README.rst` dengan bagian Work Instruction.

## Referensi

Closes #76

## Verifikasi lokal

Keenam validator kepatuhan (`module`, `ik`, `po`, `web`, `unit-test`, `tour`) dijalankan
dan lolos `0 ERROR` pada modul ini; `pre-commit-gate.sh` mencetak `GATE OK`.