### PR TITLE
[UPD] ssi_partner_public_offering - lengkapi docstring, IK, dan tour

### DIFF
--- a/ssi_partner_public_offering/README.rst
+++ b/ssi_partner_public_offering/README.rst
@@ -7,6 +7,13 @@ Company Partner's Public Offering Information
 =============================================
 
 
+Work Instruction
+================
+
+* `Company Public Offering Type <docs/company_public_offering_type/index.html>`_
+* `Contact <docs/res_partner/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_partner_public_offering/__manifest__.py
+++ b/ssi_partner_public_offering/__manifest__.py
@@ -13,10 +13,12 @@
     "depends": [
         "ssi_master_data_mixin",
         "ssi_partner",
+        "web_tour",
     ],
     "data": [
         "security/res_group_data.xml",
         "security/ir.model.access.csv",
+        "views/assets.xml",
         "views/company_public_offering_type_views.xml",
         "views/res_partner_views.xml",
     ],

--- a/ssi_partner_public_offering/docs/company_public_offering_type/01-create.md
+++ b/ssi_partner_public_offering/docs/company_public_offering_type/01-create.md
@@ -1,0 +1,40 @@
+# Create Company Public Offering Type
+
+> **Module:** ssi_partner_public_offering\
+> **Model:** `company_public_offering_type`\
+> **Menu:** Contacts > Configuration > Public Offering Types\
+> **Actor:** user in group `Public Offering Types`\
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Config:** An active `sequence.template` for model `company_public_offering_type` is
+  configured. Only needed if the **Generate Code** button will be used to auto-assign
+  the **Code** field.
+- **Access:** User is in group `Public Offering Types`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Public Offering Types** menu.
+2. Click the **Create** button.
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter a name that identifies this public offering type (e.g.
+     "Initial Public Offering").
+   - **Code** _(required)_: Enter a unique code, or enter **/** to leave it blank for
+     now and assign it later with the **Generate Code** button.
+4. Click **Generate Code** in the header to assign a value to the **Code** field from
+   the configured sequence template. Only applies when **Code** is still **/** — records
+   with a manually entered code are left unchanged. Skip this step if a code was already
+   entered manually in step 3.
+5. Optionally fill in the **Note** tab with free-text notes about this public offering
+   type.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new **Company Public Offering Type** record is created and appears in the Public
+  Offering Types list.
+- If **Generate Code** was used, the **Code** field now holds a value from the
+  configured sequence template.
+- The record becomes selectable in the **Public Offering** field on `res.partner`
+  records.

--- a/ssi_partner_public_offering/docs/company_public_offering_type/02-edit.md
+++ b/ssi_partner_public_offering/docs/company_public_offering_type/02-edit.md
@@ -1,0 +1,30 @@
+# Edit Company Public Offering Type
+
+> **Module:** ssi_partner_public_offering\
+> **Model:** `company_public_offering_type`\
+> **Menu:** Contacts > Configuration > Public Offering Types\
+> **Actor:** user in group `Public Offering Types`\
+> **Requires:** `01-create`\
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Record:** The record to edit already exists.
+- **Access:** User is in group `Public Offering Types`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Public Offering Types** menu.
+2. Find and open the record to edit.
+3. Change the **Name**, **Code**, or **Note** fields as needed.
+4. Click **Generate Code** in the header to assign a value to the **Code** field from
+   the configured sequence template — for example after resetting **Code** back to
+   **/**. Only applies when **Code** is still **/**; records with a manually entered
+   code are left unchanged.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- If **Generate Code** was used, the **Code** field now holds a value from the
+  configured sequence template.

--- a/ssi_partner_public_offering/docs/company_public_offering_type/03-delete.md
+++ b/ssi_partner_public_offering/docs/company_public_offering_type/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Company Public Offering Type
+
+> **Module:** ssi_partner_public_offering\
+> **Model:** `company_public_offering_type`\
+> **Menu:** Contacts > Configuration > Public Offering Types\
+> **Actor:** user in group `Public Offering Types`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is not referenced by any `res.partner` record.
+- **Access:** User is in group `Public Offering Types`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Public Offering Types** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_partner_public_offering/docs/company_public_offering_type/04-deactivate.md
+++ b/ssi_partner_public_offering/docs/company_public_offering_type/04-deactivate.md
@@ -1,0 +1,26 @@
+# Deactivate Company Public Offering Type
+
+> **Module:** ssi_partner_public_offering\
+> **Model:** `company_public_offering_type`\
+> **Menu:** Contacts > Configuration > Public Offering Types\
+> **Actor:** user in group `Public Offering Types`\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Public Offering Types`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Public Offering Types** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated public offering types cannot be selected on new `res.partner` records.
+- Partners that already reference this public offering type can still be viewed.

--- a/ssi_partner_public_offering/docs/company_public_offering_type/05-activate.md
+++ b/ssi_partner_public_offering/docs/company_public_offering_type/05-activate.md
@@ -1,0 +1,25 @@
+# Activate Company Public Offering Type
+
+> **Module:** ssi_partner_public_offering\
+> **Model:** `company_public_offering_type`\
+> **Menu:** Contacts > Configuration > Public Offering Types\
+> **Actor:** user in group `Public Offering Types`\
+> **Active:** `false` → `true`\
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Public Offering Types`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Public Offering Types** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected again on `res.partner` records.

--- a/ssi_partner_public_offering/docs/res_partner/01-create.md
+++ b/ssi_partner_public_offering/docs/res_partner/01-create.md
@@ -1,0 +1,13 @@
+# Create Contact
+
+> **Module:** ssi_partner_public_offering\
+> **Extends:** ssi_partner — model `res.partner`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the Contacts form gains one field, on the **Company
+Information** page (company contacts only, i.e. **Company** is selected instead of
+**Individual**):
+
+- **Public Offering**: One or more public offering types the company is involved in,
+  selected from the **Public Offering Type** master data. Optional.

--- a/ssi_partner_public_offering/models/company_public_offering_type.py
+++ b/ssi_partner_public_offering/models/company_public_offering_type.py
@@ -6,6 +6,12 @@ from odoo import models
 
 
 class CompanyPublicOfferingType(models.Model):
+    """
+    Represents a type of public offering a company partner can be
+    associated with (e.g. stock, bond). Used as master data for the
+    ``public_offering_ids`` field on ``res.partner``.
+    """
+
     _name = "company_public_offering_type"
     _inherit = ["mixin.master_data"]
     _description = "Company Public Offering Type"

--- a/ssi_partner_public_offering/models/res_partner.py
+++ b/ssi_partner_public_offering/models/res_partner.py
@@ -7,6 +7,12 @@ from odoo import fields, models
 
 
 class ResPartner(models.Model):
+    """
+    Adds public offering type traceability to partners.
+    Links a partner to the ``company_public_offering_type`` records that
+    describe which public offerings the company is involved in.
+    """
+
     _name = "res.partner"
     _inherit = "res.partner"
 

--- a/ssi_partner_public_offering/static/tests/tours/company_public_offering_type_tour.js
+++ b/ssi_partner_public_offering/static/tests/tours/company_public_offering_type_tour.js
@@ -1,0 +1,133 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_partner_public_offering.company_public_offering_type_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block -- Flow 1 of the company_public_offering_type
+    // IK: "Open the Contacts > Configuration > Public Offering Types menu."
+    function openCompanyPublicOfferingTypeList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the Public Offering Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner_public_offering.company_public_offering_type_menu"]',
+            },
+            {
+                // Gate on the TARGET action's breadcrumb, not merely "a list
+                // is on screen" (odoo-development-ui-test patterns.md §A).
+                content: "Public Offering Type list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Public Offering Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/company_public_offering_type/01-create.md
+    tour.register(
+        "ssi_partner_public_offering_company_public_offering_type_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // ── Flow 1 — Open the Public Offering Types menu.
+            openCompanyPublicOfferingTypeList(),
+            [
+                // ── Flow 2 — Click the Create button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Flow 3 — Fill in the required fields (Name, Code). Code
+                // is left as "/" so the Generate Code button of Flow 4
+                // actually assigns a value.
+                {
+                    content: "Fill in Name",
+                    trigger: ".o_field_widget[name='name']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR PUBLIC OFFERING TYPE Create",
+                },
+                {
+                    content: "Fill in Code",
+                    trigger: ".o_field_widget[name='code']",
+                    run: "text /",
+                },
+
+                // ── Flow 4 — Click Generate Code in the header. This is an
+                // inline action of this IK (metadata "Inline Actions:
+                // action_generate_code").
+                {
+                    content: "Click Generate Code",
+                    trigger: ".o_statusbar_buttons button[name='action_generate_code']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                },
+                {
+                    // The record has no id until this button auto-saves it,
+                    // so the breadcrumb literal "New" going away is the
+                    // data-independent proof the save+reload completed
+                    // (odoo-development-ui-test patterns.md §P). The
+                    // generated Code value itself is a value fact, verified
+                    // by the unit tests.
+                    content: "Record is saved by Generate Code",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:not(:contains(New))",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+
+                // ── Flow 6 — Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // ── Post-Condition — A new Company Public Offering Type
+                // record is created and appears in the Public Offering
+                // Types list, and the Code now holds a value from the
+                // sequence template. Only what is visible is asserted here.
+                {
+                    content: "Record is saved and displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(TOUR PUBLIC OFFERING TYPE Create)",
+                    extra_trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_partner_public_offering/tests/__init__.py
+++ b/ssi_partner_public_offering/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_public_offering  # noqa: F401
+from . import test_ui_company_public_offering_type  # noqa: F401

--- a/ssi_partner_public_offering/tests/test_public_offering.py
+++ b/ssi_partner_public_offering/tests/test_public_offering.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestPublicOffering(YamlTransactionCase):
+    """Cover the ``company_public_offering_type`` master data model."""
+
     def test_public_offering(self):
+        """Run the public offering type creation scenario."""
         self.run_yaml_scenario("test_data_public_offering.yaml")

--- a/ssi_partner_public_offering/tests/test_ui_company_public_offering_type.py
+++ b/ssi_partner_public_offering/tests/test_ui_company_public_offering_type.py
@@ -1,0 +1,75 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiCompanyPublicOfferingType(HttpSavepointCase):
+    """UI/UX tour test for the ``company_public_offering_type`` work
+    instruction.
+
+    ``test_create`` runs the tour paired with the IK file named in its
+    docstring (``docs/company_public_offering_type/01-create.md``).
+    Pre-Condition data of that IK file is prepared here in Python -- never
+    through UI steps -- so the tour only walks the click-flow the IK
+    documents.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Prepare the IK Pre-Conditions for the create tour.
+
+        Covers ``Access`` (admin is put in the Public Offering Types
+        group) and ``Config`` (a ``sequence.template`` for
+        ``company_public_offering_type``, without which the Generate Code
+        button raises a ``UserError`` instead of assigning a code).
+        """
+        super().setUpClass()
+
+        cls.user_admin = cls.env.ref("base.user_admin")
+        cls.group_public_offering_type = cls.env.ref(
+            "ssi_partner_public_offering."
+            "contact_public_offering_type_configurator_group"
+        )
+        cls.group_public_offering_type.sudo().write(
+            {
+                "users": [(4, cls.user_admin.id)],
+            }
+        )
+
+        cls.code_sequence = cls.env["ir.sequence"].create(
+            {
+                "name": "TOUR Company Public Offering Type Code Sequence",
+                "code": "ssi_partner_public_offering.tour."
+                "company_public_offering_type",
+                "prefix": "TOURSEQCPOT",
+                "padding": 4,
+            }
+        )
+        cls.env["sequence.template"].create(
+            {
+                "name": "TOUR Company Public Offering Type Sequence " "Template",
+                "model_id": cls.env["ir.model"]._get_id("company_public_offering_type"),
+                "sequence_field_id": cls.env["ir.model.fields"]
+                ._get("company_public_offering_type", "code")
+                .id,
+                "date_field_id": cls.env["ir.model.fields"]
+                ._get("company_public_offering_type", "create_date")
+                .id,
+                "sequence_selection_method": "use_sequence",
+                "sequence_id": cls.code_sequence.id,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``company_public_offering_type``.
+
+        IK: docs/company_public_offering_type/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_public_offering_company_public_offering_type_create",
+            login="admin",
+        )

--- a/ssi_partner_public_offering/views/assets.xml
+++ b/ssi_partner_public_offering/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_partner_public_offering assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_partner_public_offering/static/tests/tours/company_public_offering_type_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menutup temuan ERROR sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-partner`
(16 Agustus 2026) pada modul `ssi_partner_public_offering`, tanpa mengubah
perilaku fungsional apa pun yang sudah berjalan.

* Tambahkan docstring pada setiap class & method yang sebelumnya kosong
  (`models/company_public_offering_type.py`, `models/res_partner.py`,
  `tests/test_public_offering.py`) sesuai format reST skill `odoo-development`.
* Tambahkan Instruksi Kerja (IK) di `docs/` — modul ini belum punya sama
  sekali sebelumnya:
  * `company_public_offering_type`: create, edit, delete, deactivate,
    activate.
  * IK delta (`Extends:`) untuk field `public_offering_ids` pada
    `res.partner`.
* Tambahkan satu UI test (tour) `create` untuk `company_public_offering_type`
  dipetakan 1:1 dari Flow IK-nya, beserta pendaftaran bundle
  `web.assets_tests` dan dependensi manifest `web_tour`.
* Perbarui `README.rst` dengan bagian Work Instruction.

## Kriteria Penerimaan

- [x] `verify-module.sh` — `error=0 defer=0`
- [x] `validate-ik.sh` — `error=0`
- [x] `validate-unit-test.sh` — `error=0`
- [x] `validate-tour.sh` — `error=0`
- [x] Direktori `docs/` ada, memuat IK untuk setiap model modul ini
- [x] Tidak ada nama field/method/model yang berubah

Closes #78