### PR TITLE
[UPD] ssi_partner_identification: IK & tour

### DIFF
--- a/ssi_partner_identification/README.rst
+++ b/ssi_partner_identification/README.rst
@@ -6,6 +6,30 @@
 Partner Identification
 ======================
 
+This module adds a dedicated **Identities** menu (Contacts > Configuration >
+Identities) and its own security groups for the ``res.partner.id_category`` and
+``res.partner.id_number`` models provided by the OCA module ``partner_identification``.
+
+**Models:**
+
+* **Partner ID Category** (``res.partner.id_category``, from ``partner_identification``)
+  — a type of identification document, e.g. "Driver License".
+* **Partner ID Number** (``res.partner.id_number``, from ``partner_identification``) —
+  an identification number issued to a partner.
+
+Work Instruction
+================
+
+* `Create Partner ID Category <docs/res_partner_id_category/01-create.html>`_
+* `Edit Partner ID Category <docs/res_partner_id_category/02-edit.html>`_
+* `Delete Partner ID Category <docs/res_partner_id_category/03-delete.html>`_
+* `Deactivate Partner ID Category <docs/res_partner_id_category/04-deactivate.html>`_
+* `Activate Partner ID Category <docs/res_partner_id_category/05-activate.html>`_
+* `Create Partner ID Number <docs/res_partner_id_number/01-create.html>`_
+* `Edit Partner ID Number <docs/res_partner_id_number/02-edit.html>`_
+* `Delete Partner ID Number <docs/res_partner_id_number/03-delete.html>`_
+* `Deactivate Partner ID Number <docs/res_partner_id_number/04-deactivate.html>`_
+* `Activate Partner ID Number <docs/res_partner_id_number/05-activate.html>`_
 
 Installation
 ============

--- a/ssi_partner_identification/__init__.py
+++ b/ssi_partner_identification/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2023 OpenSynergy Indonesia
 # Copyright 2023 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import tests  # noqa: F401

--- a/ssi_partner_identification/__manifest__.py
+++ b/ssi_partner_identification/__manifest__.py
@@ -13,6 +13,7 @@
     "depends": [
         "ssi_partner",
         "partner_identification",
+        "web_tour",
     ],
     "data": [
         "security/res_group_data.xml",
@@ -20,6 +21,7 @@
         "menu.xml",
         "views/res_partner_id_category_view.xml",
         "views/res_partner_id_number_view.xml",
+        "views/assets.xml",
     ],
     "demo": [],
 }

--- a/ssi_partner_identification/docs/res_partner_id_category/01-create.md
+++ b/ssi_partner_identification/docs/res_partner_id_category/01-create.md
@@ -1,0 +1,28 @@
+# Create Partner ID Category
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_category`\
+> **Menu:** Contacts > Configuration > Identities > ID Categories\
+> **Actor:** user in group `Partner ID Categories`
+
+## Pre-Condition
+
+- **Access:** User is in group `Partner ID Categories`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Categories** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **ID name** _(required)_: the label of this identification type, for example
+     "Driver License".
+   - **Code** _(required)_: a short abbreviation for this identification type, up to 16
+     characters, for example "driver_license".
+4. Optionally fill in **Python validation code** with a snippet that validates the
+   format of ID numbers assigned to this category. Leave empty to skip validation.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created and **Active**.
+- The category becomes selectable as **Category** when creating a Partner ID Number.

--- a/ssi_partner_identification/docs/res_partner_id_category/02-edit.md
+++ b/ssi_partner_identification/docs/res_partner_id_category/02-edit.md
@@ -1,0 +1,24 @@
+# Edit Partner ID Category
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_category`\
+> **Menu:** Contacts > Configuration > Identities > ID Categories\
+> **Actor:** user in group `Partner ID Categories`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record already exists.
+- **Access:** User is in group `Partner ID Categories`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Categories** menu.
+2. Find and open the record to edit.
+3. Click the **Edit** button.
+4. Change the required fields (**ID name**, **Code**) or the **Python validation code**.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_partner_identification/docs/res_partner_id_category/03-delete.md
+++ b/ssi_partner_identification/docs/res_partner_id_category/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Partner ID Category
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_category`\
+> **Menu:** Contacts > Configuration > Identities > ID Categories\
+> **Actor:** user in group `Partner ID Categories`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is not referenced by any Partner ID Number.
+- **Access:** User is in group `Partner ID Categories`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Categories** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_partner_identification/docs/res_partner_id_category/04-deactivate.md
+++ b/ssi_partner_identification/docs/res_partner_id_category/04-deactivate.md
@@ -1,0 +1,27 @@
+# Deactivate Partner ID Category
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_category`\
+> **Menu:** Contacts > Configuration > Identities > ID Categories\
+> **Actor:** user in group `Partner ID Categories`\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Partner ID Categories`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Categories** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated ID categories cannot be selected as the **Category** of a new Partner ID
+  Number.
+- Partner ID Numbers that already use this category can still be viewed.

--- a/ssi_partner_identification/docs/res_partner_id_category/05-activate.md
+++ b/ssi_partner_identification/docs/res_partner_id_category/05-activate.md
@@ -1,0 +1,25 @@
+# Activate Partner ID Category
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_category`\
+> **Menu:** Contacts > Configuration > Identities > ID Categories\
+> **Actor:** user in group `Partner ID Categories`\
+> **Active:** `false` → `true`\
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Partner ID Categories`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Categories** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected as the **Category** of a new Partner ID Number again.

--- a/ssi_partner_identification/docs/res_partner_id_number/01-create.md
+++ b/ssi_partner_identification/docs/res_partner_id_number/01-create.md
@@ -1,0 +1,36 @@
+# Create Partner ID Number
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_number`\
+> **Menu:** Contacts > Configuration > Identities > ID Numbers\
+> **Actor:** user in group `Partner ID Numbers`
+
+## Pre-Condition
+
+- **Data:** An active Partner ID Category record exists (e.g. "Driver License").
+- **Data:** The partner (a `res.partner` record) this ID belongs to already exists.
+- **Access:** User is in group `Partner ID Numbers`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Numbers** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Partner** _(required)_: the partner this identification belongs to.
+   - **Category** _(required)_: the identification type, for example "Driver License".
+   - **ID Number** _(required)_: the identification number itself.
+4. Optionally fill in the remaining fields:
+   - **Issued by**: another partner who issued this ID.
+   - **Place of Issuance**: the place where the ID was issued.
+   - **Issued on**: the date the ID was issued.
+   - **Valid from** / **Valid until**: the validity period of the ID.
+   - **Status**: the current renewal status of the ID.
+   - **Notes**: free-text remarks.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created and **Active**.
+- If the selected **Category** has a **Python validation code**, the **ID Number** is
+  validated against it; an invalid number is rejected with an error and the record is
+  not saved.

--- a/ssi_partner_identification/docs/res_partner_id_number/02-edit.md
+++ b/ssi_partner_identification/docs/res_partner_id_number/02-edit.md
@@ -1,0 +1,28 @@
+# Edit Partner ID Number
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_number`\
+> **Menu:** Contacts > Configuration > Identities > ID Numbers\
+> **Actor:** user in group `Partner ID Numbers`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record already exists.
+- **Access:** User is in group `Partner ID Numbers`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Numbers** menu.
+2. Find and open the record to edit.
+3. Click the **Edit** button.
+4. Change the required fields (**Partner**, **Category**, **ID Number**) or any of the
+   optional fields.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.
+- If the **Category** or **ID Number** changed and the category has a **Python
+  validation code**, the new value is validated again; an invalid number is rejected
+  with an error.

--- a/ssi_partner_identification/docs/res_partner_id_number/03-delete.md
+++ b/ssi_partner_identification/docs/res_partner_id_number/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Partner ID Number
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_number`\
+> **Menu:** Contacts > Configuration > Identities > ID Numbers\
+> **Actor:** user in group `Partner ID Numbers`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record exists.
+- **Access:** User is in group `Partner ID Numbers`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Numbers** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_partner_identification/docs/res_partner_id_number/04-deactivate.md
+++ b/ssi_partner_identification/docs/res_partner_id_number/04-deactivate.md
@@ -1,0 +1,27 @@
+# Deactivate Partner ID Number
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_number`\
+> **Menu:** Contacts > Configuration > Identities > ID Numbers\
+> **Actor:** user in group `Partner ID Numbers`\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Partner ID Numbers`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Numbers** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated ID numbers no longer appear in the related partner's **Identification
+  Numbers** tab by default.
+- The record can still be viewed by enabling the **Archived** filter.

--- a/ssi_partner_identification/docs/res_partner_id_number/05-activate.md
+++ b/ssi_partner_identification/docs/res_partner_id_number/05-activate.md
@@ -1,0 +1,25 @@
+# Activate Partner ID Number
+
+> **Module:** ssi_partner_identification\
+> **Model:** `res.partner.id_number`\
+> **Menu:** Contacts > Configuration > Identities > ID Numbers\
+> **Actor:** user in group `Partner ID Numbers`\
+> **Active:** `false` → `true`\
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Partner ID Numbers`.
+
+## Flow
+
+1. Open the **Contacts > Configuration > Identities > ID Numbers** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The record appears again in the related partner's **Identification Numbers** tab.

--- a/ssi_partner_identification/static/tests/tours/res_partner_id_category_tour.js
+++ b/ssi_partner_identification/static/tests/tours/res_partner_id_category_tour.js
@@ -1,0 +1,91 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_partner_identification.res_partner_id_category_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/res_partner_id_category/01-create.md
+    tour.register(
+        "ssi_partner_identification_res_partner_id_category_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Contacts > Configuration > Identities >
+            // ID Categories menu. "Identities" is a grouping header (has
+            // children, no action) so it renders without a
+            // data-menu-xmlid and is skipped here.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the ID Categories menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="partner_identification.menu_partner_id_category"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang.
+                content: "Partner ID Categories list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Partner ID Categories)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Fill in ID name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text Tour Test ID Category",
+            },
+            {
+                content: "Fill in Code",
+                trigger: ".o_field_widget[name='code']",
+                run: "text tour_test_cat",
+            },
+
+            // Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                // Post-Condition — a new record is created and Active.
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_partner_identification/static/tests/tours/res_partner_id_number_tour.js
+++ b/ssi_partner_identification/static/tests/tours/res_partner_id_number_tour.js
@@ -1,0 +1,108 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_partner_identification.res_partner_id_number_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/res_partner_id_number/01-create.md
+    tour.register(
+        "ssi_partner_identification_res_partner_id_number_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Contacts > Configuration > Identities >
+            // ID Numbers menu. "Identities" is a grouping header (has
+            // children, no action) so it renders without a
+            // data-menu-xmlid and is skipped here.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Contacts app",
+                trigger: '.o_app[data-menu-xmlid="contacts.menu_contacts"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_partner.res_partner_menu_config"]',
+            },
+            {
+                content: "Open the ID Numbers menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="partner_identification.menu_partner_id_numbers"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang.
+                content: "Partner ID Numbers list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Partner ID Numbers)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Select the Partner",
+                trigger: ".o_field_many2one[name='partner_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text Tour Test ID Number Partner",
+            },
+            {
+                content: "Pick the Partner from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(Tour Test ID Number Partner)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Category",
+                trigger: ".o_field_many2one[name='category_id'] input",
+                run: "text Tour Test ID Number Category",
+            },
+            {
+                content: "Pick the Category from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(Tour Test ID Number Category)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in the ID Number",
+                trigger: ".o_field_widget[name='name']",
+                run: "text TOUR-ID-0001",
+            },
+
+            // Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                // Post-Condition — a new record is created and Active.
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_partner_identification/tests/__init__.py
+++ b/ssi_partner_identification/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_ui_res_partner_id_category  # noqa: F401
+from . import test_ui_res_partner_id_number  # noqa: F401

--- a/ssi_partner_identification/tests/test_ui_res_partner_id_category.py
+++ b/ssi_partner_identification/tests/test_ui_res_partner_id_category.py
@@ -1,0 +1,23 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase does not expose
+# cls.env in setUpClass.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiResPartnerIdCategory(HttpSavepointCase):
+    """Tour tests for the ``res.partner.id_category`` work instructions."""
+
+    def test_create(self):
+        """Run the create tour for ``res.partner.id_category``.
+
+        IK: docs/res_partner_id_category/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_identification_res_partner_id_category_create",
+            login="admin",
+        )

--- a/ssi_partner_identification/tests/test_ui_res_partner_id_number.py
+++ b/ssi_partner_identification/tests/test_ui_res_partner_id_number.py
@@ -1,0 +1,36 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase does not expose
+# cls.env in setUpClass.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiResPartnerIdNumber(HttpSavepointCase):
+    """Tour tests for the ``res.partner.id_number`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the partner and ID category the tour selects via the
+        many2one dropdowns (IK Pre-Condition data).
+        """
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "Tour Test ID Number Partner", "is_company": True}
+        )
+        cls.category = cls.env["res.partner.id_category"].create(
+            {"name": "Tour Test ID Number Category", "code": "tour_test_idn"}
+        )
+
+    def test_create(self):
+        """Run the create tour for ``res.partner.id_number``.
+
+        IK: docs/res_partner_id_number/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_partner_identification_res_partner_id_number_create",
+            login="admin",
+        )

--- a/ssi_partner_identification/views/assets.xml
+++ b/ssi_partner_identification/views/assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_partner_identification assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_partner_identification/static/tests/tours/res_partner_id_category_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_partner_identification/static/tests/tours/res_partner_id_number_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) dan tour UI untuk kedua model yang diakseskan
modul `ssi_partner_identification` (model `res.partner.id_category` dan
`res.partner.id_number`, didefinisikan di modul OCA `partner_identification`;
modul ini menyediakan menu `Contacts > Configuration > Identities` beserta
grup keamanannya sendiri — `Partner ID Categories` dan `Partner ID Numbers`).

- `docs/res_partner_id_category/` — 01-create, 02-edit, 03-delete,
  04-deactivate, 05-activate
- `docs/res_partner_id_number/` — 01-create, 02-edit, 03-delete,
  04-deactivate, 05-activate
- Tour `web_tour` untuk aksi create tiap model (`static/tests/tours/`),
  dipetakan 1:1 dari Flow IK `01-create.md`, dijalankan lewat
  `tests/test_ui_res_partner_id_category.py` dan
  `tests/test_ui_res_partner_id_number.py`
- `views/assets.xml` (bundle `web.assets_tests`) + dependensi `web_tour` di
  manifest
- `README.rst` — bagian Work Instruction disinkronkan dengan IK baru

Modul ini tidak mendefinisikan model sendiri (glue menu & ACL atas OCA
`partner_identification`), jadi tidak ada perubahan perilaku fungsional apa
pun — murni penambahan dokumentasi + test UI.

## Kepatuhan

- `pre-commit-gate.sh`: `GATE OK` — keenam validator, 0 pelanggaran baru
- `validate-ik.sh`, `validate-tour.sh`, `verify-module.sh`: masing-masing
  `0 ERROR, 0 peringatan, 0 tertunda`

Closes #79